### PR TITLE
Prune public modifier from tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class GreeterTest {
+class GreeterTest {
     @Test
-    public void testLocate() {
+    void testLocate() {
         Greeter greeter = new GreeterLocator().findGreeter();
         assertFalse(greeter.hello().isBlank());
     }

--- a/test-project/greeter.provider.test/src/test/java/tests/GreeterTest.java
+++ b/test-project/greeter.provider.test/src/test/java/tests/GreeterTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class GreeterTest {
+class GreeterTest {
     @Test
-    public void testLocate() {
+    void testLocate() {
         Greeter greeter = new GreeterLocator().findGreeter();
         assertFalse(greeter.hello().isBlank());
     }

--- a/test-project/greeter.provider/src/test/java/examples/greeter/FriendlyTest.java
+++ b/test-project/greeter.provider/src/test/java/examples/greeter/FriendlyTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class FriendlyTest {
     @Test
-    public void testGreeting() {
+    void testGreeting() {
         String greeting = new Friendly().hello();
         assertTrue(greeting.contains("welcome"));
     }


### PR DESCRIPTION
The `public` modifier is no longer needed when using JUnit Jupiter.