### PR TITLE
Support module-info.test

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
@@ -12,6 +12,8 @@ class CompileJavaTaskMutator {
         var compilerArgs = new ArrayList<>(compileJava.getOptions().getCompilerArgs());
         compilerArgs.addAll(List.of("--module-path", compileJava.getClasspath().getAsPath()));
 
+        ModuleInfoTestHelper.mutateArgs(project, project.getName(), compilerArgs::add);
+
         compileJava.getOptions().setCompilerArgs(compilerArgs);
         compileJava.setClasspath(project.files());
     }

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
@@ -31,6 +31,8 @@ public class CompileTestTask {
                         "--add-reads", moduleName + "=" + testEngine.moduleName));
             });
 
+            ModuleInfoTestHelper.mutateArgs(project, moduleName, args::add);
+
             compileTestJava.getOptions().setCompilerArgs(args);
             compileTestJava.setClasspath(project.files());
         });

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/ModuleInfoTestHelper.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/ModuleInfoTestHelper.java
@@ -1,0 +1,39 @@
+package org.javamodularity.moduleplugin.tasks;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.function.Consumer;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+
+class ModuleInfoTestHelper {
+
+	private static final Logger LOGGER = Logging.getLogger(ModuleInfoTestHelper.class);
+
+	static void mutateArgs(Project project, String moduleName, Consumer<String> consumer) {
+		var javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+		var testSourceSet = javaConvention.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME);
+		var files = testSourceSet.getAllSource().matching(f -> f.include("module-info.test"));
+		if (files.isEmpty()) {
+			LOGGER.debug("File 'module-info.test' is not present in {}", project);
+			return;
+		}
+
+		var moduleInfoTestPath = files.getSingleFile().toPath();
+		LOGGER.debug("Using lines of '{}' to patch module {}...", moduleInfoTestPath, moduleName);
+		try (var lines = Files.lines(moduleInfoTestPath)) {
+			lines.map(String::trim) //
+					.filter(line -> !line.isEmpty()) //
+					.filter(line -> !line.startsWith("//")) //
+					.peek(line -> LOGGER.debug("  {}", line)) //
+					.forEach(consumer);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Reading " + moduleInfoTestPath + " failed", e);
+		}
+	}
+}

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
@@ -64,6 +64,8 @@ public class TestTask {
                 });
             });
 
+            ModuleInfoTestHelper.mutateArgs(project, moduleName, args::add);
+
             testJava.setJvmArgs(args);
             testJava.setClasspath(project.files());
         });

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -34,7 +34,7 @@ class ModulePluginSmokeTest {
                 .withProjectDir(new File("test-project"))
                 .withPluginClasspath(pluginClasspath)
                 .withGradleVersion("4.10.2")
-                .withArguments("clean", "build", "-PINTERNAL_TEST_IN_PROGRESS")
+                .withArguments("clean", "build", "-PINTERNAL_TEST_IN_PROGRESS", "--debug", "--stacktrace")
                 .build();
 
 

--- a/test-project/greeter.provider/src/test/java/examples/greeter/ScriptingTest.java
+++ b/test-project/greeter.provider/src/test/java/examples/greeter/ScriptingTest.java
@@ -1,0 +1,13 @@
+package examples.greeter;
+
+import javax.script.*;
+import org.junit.jupiter.api.*;
+
+class ScriptingTest {
+
+    @Test
+    void testScripting() {
+        ScriptEngineManager manager = new ScriptEngineManager();
+        Assertions.assertNotNull(manager.getEngineFactories());
+    }
+}

--- a/test-project/greeter.provider/src/test/java/module-info.test
+++ b/test-project/greeter.provider/src/test/java/module-info.test
@@ -1,0 +1,7 @@
+// make module visible
+--add-modules
+  java.scripting
+
+// "requires java.scripting"
+--add-reads
+  greeter.provider=java.scripting


### PR DESCRIPTION
Support `module-info.test` configuration files.

Kudos to @marcphilipp for helping with some Gradle-foo.

Fixes #17 