### PR TITLE
fix for javadoc

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
+++ b/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
@@ -3,10 +3,7 @@ package org.javamodularity.moduleplugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
-import org.javamodularity.moduleplugin.tasks.CompileTask;
-import org.javamodularity.moduleplugin.tasks.CompileTestTask;
-import org.javamodularity.moduleplugin.tasks.RunTask;
-import org.javamodularity.moduleplugin.tasks.TestTask;
+import org.javamodularity.moduleplugin.tasks.*;
 
 import java.util.Optional;
 
@@ -22,6 +19,7 @@ public class ModuleSystemPlugin implements Plugin<Project> {
             new CompileTestTask().configureCompileTestJava(project, moduleName);
             new TestTask().configureTestJava(project, moduleName);
             new RunTask().configureRun(project, moduleName);
+            new JavadocTask().configureJavaDoc(project);
         });
     }
 

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
@@ -1,0 +1,22 @@
+package org.javamodularity.moduleplugin.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.external.javadoc.CoreJavadocOptions;
+
+public class JavadocTask {
+    public void configureJavaDoc(Project project) {
+        Javadoc javadoc = (Javadoc) project.getTasks().findByName(JavaPlugin.JAVADOC_TASK_NAME);
+        if (javadoc != null) {
+
+            javadoc.doFirst(task -> {
+                CoreJavadocOptions options = (CoreJavadocOptions) javadoc.getOptions();
+                options.addStringOption("-module-path", javadoc.getClasspath().getAsPath());
+                javadoc.setClasspath(project.files());
+            });
+
+        }
+
+    }
+}

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -34,7 +34,7 @@ class ModulePluginSmokeTest {
                 .withProjectDir(new File("test-project"))
                 .withPluginClasspath(pluginClasspath)
                 .withGradleVersion("4.10.2")
-                .withArguments("clean", "build", "-PINTERNAL_TEST_IN_PROGRESS")
+                .withArguments("clean", "build", "javadoc", "-PINTERNAL_TEST_IN_PROGRESS")
                 .build();
 
 

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -39,5 +39,8 @@ subprojects {
         testImplementation 'org.junit.jupiter:junit-jupiter-params:5.2.0'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.2.0'
     }
-    
+
+    javadoc {
+
+    }
 }

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -17,7 +17,7 @@ subprojects {
         apply plugin: "org.javamodularity.moduleplugin"
     }
     
-    version "1.0.0"
+    version "1.0.1"
 
     sourceCompatibility = 11
     targetCompatibility = 11
@@ -41,6 +41,7 @@ subprojects {
     }
 
     javadoc {
-
     }
+
+    build.dependsOn javadoc
 }


### PR DESCRIPTION
Add `--module-path` for Javadoc task.
This does not support adding extra `--add-modules` yet.