### PR TITLE
also apply run task when no module is used in the project

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
+++ b/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
@@ -18,6 +18,7 @@ public class ModuleSystemPlugin implements Plugin<Project> {
             new CompileTask().configureCompileJava(project);
             new CompileTestTask().configureCompileTestJava(project, moduleName);
             new TestTask().configureTestJava(project, moduleName);
+            new RunTask().configureRun(project, moduleName);
             new JavadocTask().configureJavaDoc(project);
         }, () -> {
             new RunTask().configureRun(project, "");

--- a/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
+++ b/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
@@ -13,13 +13,14 @@ public class ModuleSystemPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().apply(JavaPlugin.class);
         Optional<String> foundModuleName = new ModuleName().findModuleName(project);
-        foundModuleName.ifPresent(moduleName -> {
+        foundModuleName.ifPresentOrElse(moduleName -> {
             project.getExtensions().add("moduleName", moduleName);
             new CompileTask().configureCompileJava(project);
             new CompileTestTask().configureCompileTestJava(project, moduleName);
             new TestTask().configureTestJava(project, moduleName);
-            new RunTask().configureRun(project, moduleName);
             new JavadocTask().configureJavaDoc(project);
+        }, () -> {
+            new RunTask().configureRun(project, "");
         });
     }
 

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/RunTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/RunTask.java
@@ -37,10 +37,14 @@ public class RunTask {
         startScriptsTask.doFirst(task -> {
             startScriptsTask.setClasspath(project.files());
 
-            var moduleJvmArgs = List.of(
-                    "--module-path", LIBS_PLACEHOLDER,
-                    "--module", getMainClass(moduleName, execTask)
+            var moduleJvmArgs = new ArrayList<>(List.of(
+                    "--module-path", LIBS_PLACEHOLDER)
             );
+            if (!moduleName.isEmpty()) {
+                moduleJvmArgs.addAll(List.of(
+                        "--module", getMainClass(moduleName, execTask))
+                );
+            }
 
             var jvmArgs = new ArrayList<String>();
 
@@ -68,10 +72,14 @@ public class RunTask {
     private void updateJavaExecTask(JavaExec execTask, String moduleName) {
         execTask.doFirst(task -> {
 
-            var moduleJvmArgs = List.of(
-                    "--module-path", execTask.getClasspath().getAsPath(),
-                    "--module", getMainClass(moduleName, execTask)
+            var moduleJvmArgs = new ArrayList<>(List.of(
+                    "--module-path", execTask.getClasspath().getAsPath())
             );
+            if (!moduleName.isEmpty()) {
+                moduleJvmArgs.addAll(List.of(
+                        "--module", getMainClass(moduleName, execTask))
+                );
+            }
 
             var jvmArgs = new ArrayList<String>();
 


### PR DESCRIPTION
This PR is a fix for issue #23. It works by removing the `--module` argument from the java command when the project is not defined as a module.