### PR TITLE
Split a test project into 3 separate test projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.10.0'
+    id 'maven-publish' // used for publishing to local maven repository
 }
 
 group 'org.javamodularity'
@@ -64,4 +65,14 @@ pluginBundle {
     website = 'https://github.com/java9-modularity/gradle-modules-plugin'
     vcsUrl = 'git@github.com:java9-modularity/gradle-modules-plugin.git'
     tags = ['java', 'modules', 'jpms', 'modularity']
+}
+
+publishing { // used for publishing to local maven repository
+    publications {
+        maven(MavenPublication) {
+            groupId = 'org.javamodularity'
+            artifactId = 'moduleplugin'
+            version = project.version
+        }
+    }
 }

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -31,17 +31,13 @@ class ModulePluginSmokeTest {
     @Test
     void smokeTest() {
         var result = GradleRunner.create()
-                .withProjectDir(new File("test-project"))
+                .withProjectDir(new File("test-project/"))
                 .withPluginClasspath(pluginClasspath)
                 .withGradleVersion("4.10.2")
-                .withArguments("clean", "build", "-PINTERNAL_TEST_IN_PROGRESS", "--debug", "--stacktrace")
+                .withArguments("-c", "smoke_test_settings.gradle", "clean", "build", "--stacktrace")
+                .forwardOutput()
                 .build();
 
-
-        System.out.println("Build result");
-        System.out.println("============");
-        System.out.println(result.getOutput());
-        System.out.println("============");
         assertEquals(TaskOutcome.SUCCESS, result.task(":greeter.api:build").getOutcome(), "Failed Build!");
         assertEquals(TaskOutcome.SUCCESS, result.task(":greeter.provider:build").getOutcome(), "Failed Build!");
         assertEquals(TaskOutcome.SUCCESS, result.task(":greeter.provider.test:build").getOutcome(), "Failed Build!");

--- a/test-project/README.md
+++ b/test-project/README.md
@@ -7,19 +7,34 @@ It is also used as an internal test project for testing unpublished plugin chang
 Standalone test product
 ===
 To run this product as a standalone test product use this command (launched from `test-project` directory):
-
 ```
 ../gradlew clean build
 ```
 
-It will use a current plugin version from Gradle maven repository to compile the test project with
+It will use the most recent plugin version from Gradle maven repository to compile the test project with
 modules and run the unit tests.
+
+Testing locally published plugin
+===
+
+You can publish the plugin locally by running this command from the root directory:
+
+`./gradlew publishToMavenLocal`
+
+You can test the locally published plugin by running the following command from `test-project` directory.
+
+`../gradlew -c local_maven_settings.gradle clean build` 
+
+It will use the latest locally published version of the plugin  to compile the test project with 
+modules and run the unit tests.
+
 
 Internal test project
 ===
 
-This mode is enabled in `ModulePluginSmokeTest` by passing an extra parameter (`-PINTERNAL_TEST_IN_PROGRESS`) that disables
-dependency resolution of a plugin jar. The test makes the plugin under development available
+This mode is enabled in `ModulePluginSmokeTest` by passing an extra parameter (`-c smoke_test_settings.gradle`)
+that points to `smoke_test_build.gradle` instead of `build.gradle`. It doesn't resolve a plugin jar.
+Instead, it relies on the smoke test to makes the plugin under development available
 to the test project by sharing a classpath (using Gradle TestKit).
 
-__CAUTION:__ If the parameter is used outside of test, it will break the build because the plugin jar won't be resolved.
+__CAUTION:__ This approach won't work outside of the smoke test, it will break the build because the plugin jar won't be resolved.

--- a/test-project/local_maven_build.gradle
+++ b/test-project/local_maven_build.gradle
@@ -1,19 +1,16 @@
 buildscript {
     repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        mavenLocal()
+        mavenCentral()
     }
     dependencies {
-        classpath "gradle.plugin.org.javamodularity:moduleplugin:1.+"
+        classpath "org.javamodularity:moduleplugin:1.+"
     }
 }
 
 subprojects {
     apply plugin: 'java'
-    if (!project.hasProperty("INTERNAL_TEST_IN_PROGRESS")) {
-        apply plugin: "org.javamodularity.moduleplugin"
-    }
+    apply plugin: "org.javamodularity.moduleplugin"
 
     version "1.1.0"
 

--- a/test-project/local_maven_settings.gradle
+++ b/test-project/local_maven_settings.gradle
@@ -1,0 +1,8 @@
+rootProject.name = 'moduleplugintests'
+rootProject.buildFileName = 'local_maven_build.gradle'
+include 'greeter.api'
+
+include 'greeter.provider'
+include 'greeter.runner'
+include 'greeter.provider.test'
+

--- a/test-project/smoke_test_build.gradle
+++ b/test-project/smoke_test_build.gradle
@@ -4,16 +4,10 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
     }
-    dependencies {
-        classpath "gradle.plugin.org.javamodularity:moduleplugin:1.+"
-    }
 }
 
 subprojects {
     apply plugin: 'java'
-    if (!project.hasProperty("INTERNAL_TEST_IN_PROGRESS")) {
-        apply plugin: "org.javamodularity.moduleplugin"
-    }
 
     version "1.1.0"
 

--- a/test-project/smoke_test_settings.gradle
+++ b/test-project/smoke_test_settings.gradle
@@ -1,0 +1,8 @@
+rootProject.name = 'moduleplugintests'
+rootProject.buildFileName = 'smoke_test_build.gradle'
+include 'greeter.api'
+
+include 'greeter.provider'
+include 'greeter.runner'
+include 'greeter.provider.test'
+


### PR DESCRIPTION
one to be used independently, one to be used against a locally published plugin, and another one for the smoke test.

Enabled output forwarding in the smoke test so the output doesnt have to be captured independently.

Updated the docs