### PR TITLE
Fixed #36 by replacing ":" with File.pathSeparator

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
@@ -15,6 +15,8 @@ import java.io.FileNotFoundException;
 import java.io.UncheckedIOException;
 import java.util.*;
 
+import static java.io.File.pathSeparator;
+
 public class TestTask {
 
     private static final Logger LOGGER = Logging.getLogger(TestTask.class);
@@ -40,8 +42,8 @@ public class TestTask {
             args.addAll(List.of(
                     "--module-path", testJava.getClasspath().getAsPath(),
                     "--patch-module", moduleName + "=" + testSourceSet.getJava().getOutputDir().toPath()
-                            + ":" + mainSourceSet.getOutput().getResourcesDir().toPath()
-                            + ":" + testSourceSet.getOutput().getResourcesDir().toPath(),
+                            + pathSeparator + mainSourceSet.getOutput().getResourcesDir().toPath()
+                            + pathSeparator + testSourceSet.getOutput().getResourcesDir().toPath(),
                     "--add-modules", "ALL-MODULE-PATH"
             ));
 


### PR DESCRIPTION
Tested on a Windows 7 machine:
Running
```bash
../gradlew clean build
```
from `test-project` triggered the reported error:
```
> Task :greeter.provider:test FAILED
Error occurred during initialization of boot layer
java.lang.ExceptionInInitializerError
Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 116: C:\cygwin64\home\90019249\repos-external\gradle-modules-plugin\test-project\greeter.provider\build\classes\java\test:C:\cygwin64\home\90019249\repos-external\gradle-modules-plugin\test-project\greeter.provider\build\resources\main:C:\cygwin64\home\90019249\repos-external\gradle-modules-plugin\test-project\greeter.provider\build\resources\test
```

After running
```bash
./gradlew publishToMavenLocal
```
from the root directory, running
```bash
../gradlew -c local_maven_settings.gradle clean build
```
from `test-project` finished successfully:
```
...
BUILD SUCCESSFUL in 17s
25 actionable tasks: 23 executed, 2 up-to-date
```