### PR TITLE
only add --patch-modules jvm argument when the project is modular

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/RunTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/RunTask.java
@@ -78,13 +78,13 @@ public class RunTask {
             SourceSet mainSourceSet = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 
             var moduleJvmArgs = new ArrayList<>(List.of(
-                    "--module-path", execTask.getClasspath().getAsPath(),
-                    "--patch-module", moduleName + "=" + mainSourceSet.getOutput().getResourcesDir().toPath())
-            );
+                    "--module-path", execTask.getClasspath().getAsPath()
+            ));
             if (!moduleName.isEmpty()) {
                 moduleJvmArgs.addAll(List.of(
-                        "--module", getMainClass(moduleName, execTask))
-                );
+                        "--module", getMainClass(moduleName, execTask),
+                        "--patch-module", moduleName + "=" + mainSourceSet.getOutput().getResourcesDir().toPath()
+                ));
             }
 
             var jvmArgs = new ArrayList<String>();


### PR DESCRIPTION
This PR removes the --patch-modules JVM argument when the gradle project is not modular, which allows the project to run.