### PR TITLE
issue #47 revert support for non-modular projects

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
+++ b/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
@@ -13,7 +13,7 @@ public class ModuleSystemPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().apply(JavaPlugin.class);
         Optional<String> foundModuleName = new ModuleName().findModuleName(project);
-        foundModuleName.ifPresentOrElse(moduleName -> {
+        foundModuleName.ifPresent(moduleName -> {
             project.getExtensions().add("moduleName", moduleName);
             new CompileTask().configureCompileJava(project);
             new CompileTestTask().configureCompileTestJava(project, moduleName);
@@ -21,8 +21,6 @@ public class ModuleSystemPlugin implements Plugin<Project> {
             new RunTask().configureRun(project, moduleName);
             new JavadocTask().configureJavaDoc(project);
             ModularJavaExec.configure(project, moduleName);
-        }, () -> {
-            new RunTask().configureRun(project, "");
         });
 
     }

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
@@ -46,14 +46,10 @@ public class RunTaskMutator {
         startScriptsTask.doFirst(task -> {
             startScriptsTask.setClasspath(project.files());
 
-            var moduleJvmArgs = new ArrayList<>(List.of(
-                    "--module-path", LIBS_PLACEHOLDER)
+            var moduleJvmArgs = List.of(
+                    "--module-path", LIBS_PLACEHOLDER,
+                    "--module", getMainClass()
             );
-            if (!moduleName.isEmpty()) {
-                moduleJvmArgs.addAll(List.of(
-                        "--module", getMainClass())
-                );
-            }
 
             var jvmArgs = new ArrayList<String>();
 
@@ -84,15 +80,11 @@ public class RunTaskMutator {
 
             SourceSet mainSourceSet = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 
-            var moduleJvmArgs = new ArrayList<>(List.of(
-                    "--module-path", execTask.getClasspath().getAsPath()
-            ));
-            if (!moduleName.isEmpty()) {
-                moduleJvmArgs.addAll(List.of(
-                        "--patch-module", moduleName + "=" + mainSourceSet.getOutput().getResourcesDir().toPath(),
-                        "--module", getMainClass()
-                ));
-            }
+            var moduleJvmArgs = List.of(
+                    "--module-path", execTask.getClasspath().getAsPath(),
+                    "--patch-module", moduleName + "=" + mainSourceSet.getOutput().getResourcesDir().toPath(),
+                    "--module", getMainClass()
+            );
 
             var jvmArgs = new ArrayList<String>();
 


### PR DESCRIPTION
This PR fixes #47 by reverting all the changes that were introduced for supporting non-modular projects (aka projects without a module-info.java file).