### PR TITLE
issue #53: apply module-info.test only to test-related tasks

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
@@ -21,7 +21,6 @@ class CompileJavaTaskMutator {
             compilerArgs.add(addModules);
         }
 
-        ModuleInfoTestHelper.mutateArgs(project, project.getName(), compilerArgs::add);
         compileJava.getOptions().setCompilerArgs(compilerArgs);
         compileJava.setClasspath(project.files());
 

--- a/test-project-kotlin/greeter.provider/build.gradle.kts
+++ b/test-project-kotlin/greeter.provider/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 dependencies {
     implementation(project(":greeter.api"))
-    testImplementation("org.hamcrest:hamcrest:2.1-rc4")
+    testImplementation("org.hamcrest:hamcrest:2.1+")
 }
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {

--- a/test-project-kotlin/greeter.provider/build.gradle.kts
+++ b/test-project-kotlin/greeter.provider/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 dependencies {
     implementation(project(":greeter.api"))
+    testImplementation("org.hamcrest:hamcrest:2.1-rc4")
 }
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {

--- a/test-project-kotlin/greeter.provider/src/test/kotlin/examples/greeter/ScriptingTest.kt
+++ b/test-project-kotlin/greeter.provider/src/test/kotlin/examples/greeter/ScriptingTest.kt
@@ -2,11 +2,13 @@ package examples.greeter
 
 import javax.script.*
 import org.junit.jupiter.api.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
 
 class ScriptingTest {
     @Test
     fun testScripting() {
         val manager = ScriptEngineManager()
-        Assertions.assertNotNull(manager.getEngineFactories())
+        assertThat(manager.getEngineFactories(), not(nullValue()))
     }
 }

--- a/test-project-kotlin/greeter.provider/src/test/kotlin/module-info.test
+++ b/test-project-kotlin/greeter.provider/src/test/kotlin/module-info.test
@@ -1,7 +1,7 @@
 // make module visible
 --add-modules
-  java.scripting
+  java.scripting,org.hamcrest
 
 // "requires java.scripting"
 --add-reads
-  greeter.provider=java.scripting
+  greeter.provider=java.scripting,org.hamcrest

--- a/test-project/greeter.provider/build.gradle
+++ b/test-project/greeter.provider/build.gradle
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation project(':greeter.api')
+    testImplementation('org.hamcrest:hamcrest:2.1-rc4')
 }

--- a/test-project/greeter.provider/build.gradle
+++ b/test-project/greeter.provider/build.gradle
@@ -4,5 +4,5 @@ plugins {
 
 dependencies {
     implementation project(':greeter.api')
-    testImplementation('org.hamcrest:hamcrest:2.1-rc4')
+    testImplementation('org.hamcrest:hamcrest:2.1+')
 }

--- a/test-project/greeter.provider/src/test/java/examples/greeter/ScriptingTest.java
+++ b/test-project/greeter.provider/src/test/java/examples/greeter/ScriptingTest.java
@@ -2,12 +2,14 @@ package examples.greeter;
 
 import javax.script.*;
 import org.junit.jupiter.api.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 class ScriptingTest {
 
     @Test
     void testScripting() {
         ScriptEngineManager manager = new ScriptEngineManager();
-        Assertions.assertNotNull(manager.getEngineFactories());
+        assertThat(manager.getEngineFactories(), not(nullValue()));
     }
 }

--- a/test-project/greeter.provider/src/test/java/module-info.test
+++ b/test-project/greeter.provider/src/test/java/module-info.test
@@ -1,7 +1,7 @@
 // make module visible
 --add-modules
-  java.scripting
+  java.scripting,org.hamcrest
 
 // "requires java.scripting"
 --add-reads
-  greeter.provider=java.scripting
+  greeter.provider=java.scripting,org.hamcrest


### PR DESCRIPTION
This PR:
- extends `greeter.provider` to catch the problem raised by this issue.
- removes the call to `ModuleInfoTestHelper.mutateArgs()` from `CompileJavaTaskMutator`
