### PR TITLE
Relocate JavaParser classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'maven-publish' // used for publishing to local maven repository
+    id 'com.github.johnrengelman.shadow' version '4.0.3'
 }
 
 group 'org.javamodularity'
@@ -16,15 +17,32 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    plugin.description = 'Plugin\'s dependencies'
+    compile.extendsFrom plugin
+}
+
 dependencies {
     implementation gradleApi()
-    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.6.23'
+    plugin 'com.github.javaparser:javaparser-symbol-solver-core:3.6.23'
 
     testImplementation gradleTestKit()
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.3.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
 }
+
+shadowJar {
+    configurations = [project.configurations.plugin]
+    classifier = null
+    dependencies {
+        include(dependency('com.github.javaparser:javaparser-symbol-solver-core'))
+    }
+    relocate 'com.github.javaparser', 'org.javamodularity.moduleplugin.shadow.javaparser'
+}
+
+jar.enabled = false
+jar.dependsOn shadowJar
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION
JavaParser uses the so-called [pragmatic versioning](https://javaparser.org/pragmatic-versioning/), which means that breaking changes may occur (and they do occur) even between patch releases.

This PR relocates the JavaParser classes (using the Shadow plugin) to prevent incompatibilities with other tools.
