### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ stages:
 jobs:
   include:
     - stage: build
-      script: "./gradlew buildi --scan"
+      script: "./gradlew build --scan"
     - stage: release
       script: "./gradlew publishPlugin"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ stages:
 jobs:
   include:
     - stage: build
-      script: "./gradlew build"
+      script: "./gradlew buildi --scan"
     - stage: release
       script: "./gradlew publishPlugin"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
+    id 'com.gradle.build-scan' version '2.1'
     id 'eclipse'
     id 'java'
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'maven-publish' // used for publishing to local maven repository
     id 'com.github.johnrengelman.shadow' version '4.0.4'
-    id 'com.gradle.build-scan' version '2.1'
 }
 
 buildScan {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,12 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'maven-publish' // used for publishing to local maven repository
     id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'com.gradle.build-scan' version '2.1'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 group 'org.javamodularity'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.