### PR TITLE
Fix #89: Support for all module options in RunTask and JavadocTask

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/internal/PatchModuleResolver.java
+++ b/src/main/java/org/javamodularity/moduleplugin/internal/PatchModuleResolver.java
@@ -4,6 +4,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.javamodularity.moduleplugin.tasks.PatchModuleExtension;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
@@ -23,15 +24,16 @@ public final class PatchModuleResolver {
         this.jarNameResolver = jarNameResolver;
     }
 
-    public Stream<String> toArgumentStream() {
-        return toValueStream().flatMap(value -> Stream.of("--patch-module", value));
+    public void mutateArgs(List<String> args) {
+        buildOptionStream().forEach(option -> option.mutateArgs(args));
     }
 
-    public Stream<String> toValueStream() {
+    public Stream<TaskOption> buildOptionStream() {
         return patchModuleExtension.getConfig().stream()
                 .map(patch -> patch.split("="))
                 .map(this::resolvePatchModuleValue)
-                .filter(Objects::nonNull);
+                .filter(Objects::nonNull)
+                .map(value -> new TaskOption("--patch-module", value));
     }
 
     private String resolvePatchModuleValue(String[] parts) {

--- a/src/main/java/org/javamodularity/moduleplugin/internal/StreamHelper.java
+++ b/src/main/java/org/javamodularity/moduleplugin/internal/StreamHelper.java
@@ -1,0 +1,12 @@
+package org.javamodularity.moduleplugin.internal;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public final class StreamHelper {
+
+    @SafeVarargs
+    public static <T> Stream<T> concat(Stream<T>... streams) {
+        return Arrays.stream(streams).reduce(Stream::concat).orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/src/main/java/org/javamodularity/moduleplugin/internal/TaskOption.java
+++ b/src/main/java/org/javamodularity/moduleplugin/internal/TaskOption.java
@@ -1,0 +1,64 @@
+package org.javamodularity.moduleplugin.internal;
+
+import org.gradle.external.javadoc.CoreJavadocOptions;
+
+import java.util.List;
+
+/**
+ * Stores a flag and its value that can be used as: compiler args, JVM args, and Javadoc options.
+ */
+public final class TaskOption {
+
+    /**
+     * E.g. {@code --add-modules}.
+     */
+    private final String flag;
+    /**
+     * E.g. {@code java.sql,my.module}.
+     */
+    private final String value;
+
+    public TaskOption(String flag, String value) {
+        this.flag = flag;
+        this.value = value;
+        this.validate();
+    }
+
+    private void validate() {
+        if (!flag.startsWith("--")) {
+            throw new IllegalArgumentException("Invalid flag: " + flag);
+        }
+        if (value.isBlank() || value.contains(" ")) {
+            throw new IllegalArgumentException("Invalid value: " + value);
+        }
+    }
+
+    public String getFlag() {
+        return flag;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Javadoc takes options without the initial hyphen.
+     *
+     * @return the Javadoc flag
+     * @see org.gradle.external.javadoc.internal.JavadocOptionFileWriterContext#writeOptionHeader(String)
+     */
+    public String getJavadocFlag() {
+        return flag.substring(1);
+    }
+
+    //region MUTATE
+    public void mutateArgs(List<String> args) {
+        args.add(flag);
+        args.add(value);
+    }
+
+    public void mutateOptions(CoreJavadocOptions options) {
+        options.addStringOption(getJavadocFlag(), value);
+    }
+    //endregion
+}

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
@@ -9,7 +9,6 @@ import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 class CompileJavaTaskMutator {
 
@@ -50,16 +49,13 @@ class CompileJavaTaskMutator {
     private List<String> buildCompilerArgs(JavaCompile javaCompile) {
         var compilerArgs = new ArrayList<>(javaCompile.getOptions().getCompilerArgs());
 
-        String moduleName = helper().moduleName();
         var patchModuleExtension = helper().extension(PatchModuleExtension.class);
 
-        Stream.of("--module-path", patchModuleExtension.getUnpatchedClasspathAsPath(compileJavaClasspath))
-                .forEach(compilerArgs::add);
+        patchModuleExtension.buildModulePathOption(compileJavaClasspath)
+                .ifPresent(option -> option.mutateArgs(compilerArgs));
+        patchModuleExtension.resolvePatched(compileJavaClasspath).mutateArgs(compilerArgs);
 
-        moduleOptions.mutateArgs(moduleName, compilerArgs);
-
-        patchModuleExtension.resolve(compileJavaClasspath).toArgumentStream()
-                .forEach(compilerArgs::add);
+        moduleOptions.mutateArgs(compilerArgs);
 
         return compilerArgs;
     }

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/PatchModuleExtension.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/PatchModuleExtension.java
@@ -1,6 +1,7 @@
 package org.javamodularity.moduleplugin.tasks;
 
 import org.gradle.api.file.FileCollection;
+import org.javamodularity.moduleplugin.internal.TaskOption;
 import org.javamodularity.moduleplugin.internal.PatchModuleResolver;
 
 import java.io.File;
@@ -21,11 +22,11 @@ public class PatchModuleExtension {
         indexByJar = config.stream().map(s -> s.split("=")).collect(Collectors.toMap(c -> c[1], c -> c[0]));
     }
 
-    public PatchModuleResolver resolve(FileCollection classpath) {
-        return resolve(jarName -> classpath.filter(jar -> jar.getName().endsWith(jarName)).getAsPath());
+    public PatchModuleResolver resolvePatched(FileCollection classpath) {
+        return resolvePatched(jarName -> classpath.filter(jar -> jar.getName().endsWith(jarName)).getAsPath());
     }
 
-    public PatchModuleResolver resolve(UnaryOperator<String> jarNameResolver) {
+    public PatchModuleResolver resolvePatched(UnaryOperator<String> jarNameResolver) {
         return new PatchModuleResolver(this, jarNameResolver);
     }
 
@@ -37,8 +38,12 @@ public class PatchModuleExtension {
         return !indexByJar.containsKey(jar.getName());
     }
 
-    public String getUnpatchedClasspathAsPath(FileCollection classpath) {
-        return classpath.filter(this::isUnpatched).getAsPath();
+    public Optional<TaskOption> buildModulePathOption(FileCollection classpath) {
+        String modulePath = classpath.filter(this::isUnpatched).getAsPath();
+        if (modulePath.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new TaskOption("--module-path", modulePath));
     }
 
     @Override

--- a/src/test/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutatorTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutatorTest.java
@@ -1,6 +1,7 @@
 package org.javamodularity.moduleplugin.tasks;
 
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -22,6 +23,9 @@ class CompileJavaTaskMutatorTest {
         project.getPlugins().apply("java");
         JavaCompile compileJava = (JavaCompile) project.getTasks().getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME);
 
+        FileCollection classpath = project.files("greeter.api/src/main/java"); // we need anything on classpath
+        compileJava.setClasspath(classpath);
+
         CompileModuleOptions moduleOptions = compileJava.getExtensions()
                 .create("moduleOptions", CompileModuleOptions.class, project);
         project.getExtensions().add("moduleName", getClass().getName());
@@ -35,7 +39,7 @@ class CompileJavaTaskMutatorTest {
         // then
         List<String> twoLastArguments = twoLastCompilerArgs(compileJava);
         assertEquals(
-                Arrays.asList("--module-path", compileJava.getClasspath().getAsPath()),
+                Arrays.asList("--module-path", classpath.getAsPath()),
                 twoLastArguments,
                 "Two last arguments should be setting module path to the current compileJava task classpath");
     }


### PR DESCRIPTION
Fixes #89.

There were two tasks that had no support implemented for `--add-exports`, etc. (#74):
1. `RunTask`
2. `JavadocTask`

In order to accomodate the `JavadocTask`, I introduced a new class for holding the flag-value pairs (`TaskOption`).

After introducing it, I decided it's worth refactoring all such flag-value pairs to `TaskOption`, hence so many changes (sorry). I like the end result, though :smiley: