### PR TITLE
Fixed a regression in TaskOption

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/internal/TaskOption.java
+++ b/src/main/java/org/javamodularity/moduleplugin/internal/TaskOption.java
@@ -28,7 +28,7 @@ public final class TaskOption {
         if (!flag.startsWith("--")) {
             throw new IllegalArgumentException("Invalid flag: " + flag);
         }
-        if (value.isBlank() || value.contains(" ")) {
+        if (value.isBlank()) {
             throw new IllegalArgumentException("Invalid value: " + value);
         }
     }

--- a/src/test/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutatorTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutatorTest.java
@@ -23,7 +23,7 @@ class CompileJavaTaskMutatorTest {
         project.getPlugins().apply("java");
         JavaCompile compileJava = (JavaCompile) project.getTasks().getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME);
 
-        FileCollection classpath = project.files("greeter.api/src/main/java"); // we need anything on classpath
+        FileCollection classpath = project.files("dummy dir"); // we need anything on classpath
         compileJava.setClasspath(classpath);
 
         CompileModuleOptions moduleOptions = compileJava.getExtensions()


### PR DESCRIPTION
Sorry for trouble, but when I woke up today, I realized I introduced a regression by [disallowing spaces in `TaskOption`'s `value`](https://github.com/java9-modularity/gradle-modules-plugin/blob/4014f02a411fc4f3a4981bcc69677e10e892ab30/src/main/java/org/javamodularity/moduleplugin/internal/TaskOption.java#L31).

Spaces should definitely be allowed there:
- when they're fed to `javac`, `javadoc`, etc., they're enclosed in quotes ([example](https://github.com/gradle/gradle/blob/9e5363f5dacf64cf6eb5377493354a630e575bd1/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFileWriterContext.java#L64))
- as it is now, everyone who'll try to use the plugin with a directory structure that contains a space may have their build fail

This PR fixes this regression.

Once again, sorry about this.