### PR TITLE
Some API refactorings (fixes #80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,11 @@ compileJava {
 
 The following options are supported by the `moduleOptions` extension:
 
-* addModules: Maps to `--add-modules`. Value is of type `List<String>`, e.g, `['com.acme.foo']`.
-* addReads: Maps to `--add-reads`. Value is of type `Map<String, String>`, e.g, `['module1': 'module2']`.
-* addOpens: Maps to `--add-opens`. Value is of type `Map<String, String>`, e.g, `['module1/package': 'module2']`.
-* addExports: Maps to `--add-exports`. Value is of type `Map<String, String>`, e.g, `['module1/package': 'module2']`.
+* `addModules`: Maps to `--add-modules`. Value is of type `List<String>`, e.g, `['com.acme.foo']`.
+* `addReads`: Maps to `--add-reads`. Value is of type `Map<String, String>`, e.g, `['module1': 'module2']`.
+* `addExports`: Maps to `--add-exports`. Value is of type `Map<String, String>`, e.g, `['module1/package': 'module2']`.
+* `addOpens`: Maps to `--add-opens`. Value is of type `Map<String, String>`, e.g, `['module1/package': 'module2']`
+  (available only for `test` and `run` tasks).
 
 Note that multiple entries matching the same left hand side may be added to `addReads`, `addOpens`, and `addExports` but
 no value accumulation is performed, the last entry overrides the previous one. If you need to combine multiple values then
@@ -183,7 +184,7 @@ compileJava {
 }
 ```
 
-Where as the following block resolves to `--add-reads module1=module2,module3`
+Whereas the following block resolves to `--add-reads module1=module2,module3`
 
 ```
 compileJava {

--- a/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
+++ b/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
@@ -6,6 +6,7 @@ import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaPlugin;
 import org.javamodularity.moduleplugin.extensions.DefaultModularityExtension;
 import org.javamodularity.moduleplugin.extensions.ModularityExtension;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.javamodularity.moduleplugin.tasks.*;
 
 public class ModuleSystemPlugin implements Plugin<Project> {

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/CompileModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/CompileModuleOptions.java
@@ -4,7 +4,6 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.internal.TaskOption;
-import org.javamodularity.moduleplugin.tasks.ModuleOptions;
 
 import java.io.File;
 import java.util.List;

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/CompileTestModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/CompileTestModuleOptions.java
@@ -1,0 +1,10 @@
+package org.javamodularity.moduleplugin.extensions;
+
+import org.gradle.api.Project;
+
+public class CompileTestModuleOptions extends ModuleOptions {
+
+    public CompileTestModuleOptions(Project project) {
+        super(project);
+    }
+}

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/JavadocModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/JavadocModuleOptions.java
@@ -1,0 +1,10 @@
+package org.javamodularity.moduleplugin.extensions;
+
+import org.gradle.api.Project;
+
+public class JavadocModuleOptions extends ModuleOptions {
+
+    public JavadocModuleOptions(Project project) {
+        super(project);
+    }
+}

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/ModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/ModuleOptions.java
@@ -19,7 +19,6 @@ public abstract class ModuleOptions {
     private List<String> addModules = new ArrayList<>();
     private Map<String, String> addReads = new LinkedHashMap<>();
     private Map<String, String> addExports = new LinkedHashMap<>();
-    private Map<String, String> addOpens = new LinkedHashMap<>();
 
     protected ModuleOptions(Project project) {
         this.project = project;
@@ -49,27 +48,22 @@ public abstract class ModuleOptions {
         this.addExports = addExports;
     }
 
-    public Map<String, String> getAddOpens() {
-        return addOpens;
-    }
-
-    public void setAddOpens(Map<String, String> addOpens) {
-        this.addOpens = addOpens;
-    }
-
     //region MODULE TASK OPTION
     public void mutateArgs(List<String> args) {
-        buildFullOptionStream().forEach(o -> o.mutateArgs(args));
+        buildFullOptionStreamLogged().forEach(o -> o.mutateArgs(args));
     }
 
-    public Stream<TaskOption> buildFullOptionStream() {
+    public Stream<TaskOption> buildFullOptionStreamLogged() {
         LOGGER.debug("Updating module '{}' with...", helper().moduleName());
+        return buildFullOptionStream().peek(option -> LOGGER.debug("  {} {}", option.getFlag(), option.getValue()));
+    }
+
+    protected Stream<TaskOption> buildFullOptionStream() {
         return StreamHelper.concat(
                 addModulesOption().stream(),
                 addReadsOptionStream(),
-                addExportsOptionStream(),
-                addOpensOptionStream()
-        ).peek(option -> LOGGER.debug("  {} {}", option.getFlag(), option.getValue()));
+                addExportsOptionStream()
+        );
     }
 
     private Optional<TaskOption> addModulesOption() {
@@ -87,11 +81,7 @@ public abstract class ModuleOptions {
         return buildOptionStream("--add-exports", addExports);
     }
 
-    private Stream<TaskOption> addOpensOptionStream() {
-        return buildOptionStream("--add-opens", addOpens);
-    }
-
-    private Stream<TaskOption> buildOptionStream(String flag, Map<String, String> map) {
+    protected final Stream<TaskOption> buildOptionStream(String flag, Map<String, String> map) {
         if (map.isEmpty()) {
             return Stream.empty();
         }

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/ModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/ModuleOptions.java
@@ -1,4 +1,4 @@
-package org.javamodularity.moduleplugin.tasks;
+package org.javamodularity.moduleplugin.extensions;
 
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -6,6 +6,7 @@ import org.gradle.api.logging.Logging;
 import org.javamodularity.moduleplugin.JavaProjectHelper;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 import org.javamodularity.moduleplugin.internal.StreamHelper;
+import org.javamodularity.moduleplugin.tasks.MergeClassesHelper;
 
 import java.util.*;
 import java.util.stream.Stream;

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/ModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/ModuleOptions.java
@@ -11,7 +11,7 @@ import org.javamodularity.moduleplugin.tasks.MergeClassesHelper;
 import java.util.*;
 import java.util.stream.Stream;
 
-public class ModuleOptions {
+public abstract class ModuleOptions {
     private static final Logger LOGGER = Logging.getLogger(ModuleOptions.class);
 
     private final Project project;
@@ -21,7 +21,7 @@ public class ModuleOptions {
     private Map<String, String> addExports = new LinkedHashMap<>();
     private Map<String, String> addOpens = new LinkedHashMap<>();
 
-    public ModuleOptions(Project project) {
+    protected ModuleOptions(Project project) {
         this.project = project;
     }
 
@@ -102,7 +102,7 @@ public class ModuleOptions {
     }
     //endregion
 
-    protected JavaProjectHelper helper() {
+    protected final JavaProjectHelper helper() {
         return new JavaProjectHelper(project);
     }
 

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/PatchModuleExtension.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/PatchModuleExtension.java
@@ -1,4 +1,4 @@
-package org.javamodularity.moduleplugin.tasks;
+package org.javamodularity.moduleplugin.extensions;
 
 import org.gradle.api.file.FileCollection;
 import org.javamodularity.moduleplugin.internal.TaskOption;

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/RunModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/RunModuleOptions.java
@@ -1,0 +1,10 @@
+package org.javamodularity.moduleplugin.extensions;
+
+import org.gradle.api.Project;
+
+public class RunModuleOptions extends ModuleOptions {
+
+    public RunModuleOptions(Project project) {
+        super(project);
+    }
+}

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/RunModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/RunModuleOptions.java
@@ -2,7 +2,7 @@ package org.javamodularity.moduleplugin.extensions;
 
 import org.gradle.api.Project;
 
-public class RunModuleOptions extends ModuleOptions {
+public class RunModuleOptions extends RuntimeModuleOptions {
 
     public RunModuleOptions(Project project) {
         super(project);

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/RuntimeModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/RuntimeModuleOptions.java
@@ -1,0 +1,38 @@
+package org.javamodularity.moduleplugin.extensions;
+
+import org.gradle.api.Project;
+import org.javamodularity.moduleplugin.internal.TaskOption;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public abstract class RuntimeModuleOptions extends ModuleOptions {
+
+    private Map<String, String> addOpens = new LinkedHashMap<>();
+
+    public RuntimeModuleOptions(Project project) {
+        super(project);
+    }
+
+    public Map<String, String> getAddOpens() {
+        return addOpens;
+    }
+
+    public void setAddOpens(Map<String, String> addOpens) {
+        this.addOpens = addOpens;
+    }
+
+    //region OPTION STREAM
+    protected Stream<TaskOption> buildFullOptionStream() {
+        return Stream.concat(
+                super.buildFullOptionStream(),
+                addOpensOptionStream()
+        );
+    }
+
+    private Stream<TaskOption> addOpensOptionStream() {
+        return buildOptionStream("--add-opens", addOpens);
+    }
+    //endregion
+}

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/TestModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/TestModuleOptions.java
@@ -1,4 +1,4 @@
-package org.javamodularity.moduleplugin.tasks;
+package org.javamodularity.moduleplugin.extensions;
 
 import org.gradle.api.Project;
 

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/TestModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/TestModuleOptions.java
@@ -2,7 +2,7 @@ package org.javamodularity.moduleplugin.extensions;
 
 import org.gradle.api.Project;
 
-public class TestModuleOptions extends ModuleOptions {
+public class TestModuleOptions extends RuntimeModuleOptions {
 
     private boolean runOnClasspath;
 

--- a/src/main/java/org/javamodularity/moduleplugin/internal/PatchModuleResolver.java
+++ b/src/main/java/org/javamodularity/moduleplugin/internal/PatchModuleResolver.java
@@ -2,7 +2,7 @@ package org.javamodularity.moduleplugin.internal;
 
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.javamodularity.moduleplugin.tasks.PatchModuleExtension;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
@@ -5,11 +5,11 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.JavaProjectHelper;
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 class CompileJavaTaskMutator {
 

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
@@ -7,7 +7,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.TestEngine;
-import org.javamodularity.moduleplugin.extensions.ModuleOptions;
+import org.javamodularity.moduleplugin.extensions.CompileTestModuleOptions;
 import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 
@@ -26,7 +26,8 @@ public class CompileTestTask extends AbstractModulePluginTask {
     }
 
     private void configureCompileTestJava(JavaCompile compileTestJava) {
-        var moduleOptions = compileTestJava.getExtensions().create("moduleOptions", ModuleOptions.class, project);
+        var moduleOptions = compileTestJava.getExtensions()
+                .create("moduleOptions", CompileTestModuleOptions.class, project);
 
         // don't convert to lambda: https://github.com/java9-modularity/gradle-modules-plugin/issues/54
         compileTestJava.doFirst(new Action<Task>() {
@@ -39,7 +40,8 @@ public class CompileTestTask extends AbstractModulePluginTask {
         });
     }
 
-    private List<String> buildCompilerArgs(JavaCompile compileTestJava, ModuleOptions moduleOptions) {
+    private List<String> buildCompilerArgs(
+            JavaCompile compileTestJava, CompileTestModuleOptions moduleOptions) {
         var compilerArgs = new ArrayList<>(compileTestJava.getOptions().getCompilerArgs());
 
         String moduleName = helper().moduleName();

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
@@ -7,6 +7,8 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.TestEngine;
+import org.javamodularity.moduleplugin.extensions.ModuleOptions;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 
 import java.util.ArrayList;

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
@@ -7,7 +7,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.external.javadoc.CoreJavadocOptions;
-import org.javamodularity.moduleplugin.extensions.ModuleOptions;
+import org.javamodularity.moduleplugin.extensions.JavadocModuleOptions;
 import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.javamodularity.moduleplugin.internal.StreamHelper;
 
@@ -23,7 +23,7 @@ public class JavadocTask extends AbstractModulePluginTask {
     }
 
     private void configureJavaDoc(Javadoc javadoc) {
-        var moduleOptions = javadoc.getExtensions().create("moduleOptions", ModuleOptions.class, project);
+        var moduleOptions = javadoc.getExtensions().create("moduleOptions", JavadocModuleOptions.class, project);
 
         // don't convert to lambda: https://github.com/java9-modularity/gradle-modules-plugin/issues/54
         javadoc.doFirst(new Action<Task>() {
@@ -35,7 +35,7 @@ public class JavadocTask extends AbstractModulePluginTask {
         });
     }
 
-    private void addJavadocOptions(Javadoc javadoc, ModuleOptions moduleOptions) {
+    private void addJavadocOptions(Javadoc javadoc, JavadocModuleOptions moduleOptions) {
         var options = (CoreJavadocOptions) javadoc.getOptions();
         var patchModuleExtension = helper().extension(PatchModuleExtension.class);
         FileCollection classpath = mergeClassesHelper().getMergeAdjustedClasspath(javadoc.getClasspath());

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
@@ -43,7 +43,7 @@ public class JavadocTask extends AbstractModulePluginTask {
         StreamHelper.concat(
                 patchModuleExtension.buildModulePathOption(classpath).stream(),
                 patchModuleExtension.resolvePatched(classpath).buildOptionStream(),
-                moduleOptions.buildFullOptionStream()
+                moduleOptions.buildFullOptionStreamLogged()
         ).forEach(option -> option.mutateOptions(options));
     }
 

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/JavadocTask.java
@@ -7,6 +7,8 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.external.javadoc.CoreJavadocOptions;
+import org.javamodularity.moduleplugin.extensions.ModuleOptions;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.javamodularity.moduleplugin.internal.StreamHelper;
 
 public class JavadocTask extends AbstractModulePluginTask {

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesHelper.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesHelper.java
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.JavaProjectHelper;
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
+import org.javamodularity.moduleplugin.internal.StreamHelper;
 
 import java.io.File;
 import java.util.HashSet;
@@ -38,8 +39,9 @@ public class MergeClassesHelper {
     }
 
     private Stream<String> otherCompileTaskNameStream() {
-        return Stream.concat(
-                Stream.concat(PRE_JAVA_COMPILE_TASK_NAMES.stream(), POST_JAVA_COMPILE_TASK_NAMES.stream()),
+        return StreamHelper.concat(
+                PRE_JAVA_COMPILE_TASK_NAMES.stream(),
+                POST_JAVA_COMPILE_TASK_NAMES.stream(),
                 Stream.of(CompileModuleOptions.COMPILE_MODULE_INFO_TASK_NAME)
         );
     }

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
@@ -5,6 +5,8 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.JavaExec;
+import org.javamodularity.moduleplugin.extensions.ModuleOptions;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 
 import java.util.ArrayList;

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
@@ -5,8 +5,8 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.JavaExec;
-import org.javamodularity.moduleplugin.extensions.ModuleOptions;
 import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
+import org.javamodularity.moduleplugin.extensions.RunModuleOptions;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ public class RunTaskMutator extends AbstractExecutionMutator {
     }
 
     public void configureRun() {
-        execTask.getExtensions().create("moduleOptions", ModuleOptions.class, project);
+        execTask.getExtensions().create("moduleOptions", RunModuleOptions.class, project);
         updateJavaExecTask();
     }
 
@@ -40,7 +40,7 @@ public class RunTaskMutator extends AbstractExecutionMutator {
 
         String moduleName = helper().moduleName();
         var patchModuleExtension = helper().extension(PatchModuleExtension.class);
-        var moduleOptions = execTask.getExtensions().getByType(ModuleOptions.class);
+        var moduleOptions = execTask.getExtensions().getByType(RunModuleOptions.class);
 
         moduleOptions.mutateArgs(jvmArgs);
 

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/StartScriptsMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/StartScriptsMutator.java
@@ -10,6 +10,8 @@ import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.application.CreateStartScripts;
+import org.javamodularity.moduleplugin.extensions.ModuleOptions;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 
 import java.io.IOException;

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/StartScriptsMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/StartScriptsMutator.java
@@ -10,8 +10,8 @@ import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.application.CreateStartScripts;
-import org.javamodularity.moduleplugin.extensions.ModuleOptions;
 import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
+import org.javamodularity.moduleplugin.extensions.RunModuleOptions;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 
 import java.io.IOException;
@@ -72,7 +72,7 @@ public class StartScriptsMutator extends AbstractExecutionMutator {
         var jvmArgs = new ArrayList<String>();
 
         var patchModuleExtension = helper().extension(PatchModuleExtension.class);
-        var moduleOptions = execTask.getExtensions().getByType(ModuleOptions.class);
+        var moduleOptions = execTask.getExtensions().getByType(RunModuleOptions.class);
 
         moduleOptions.mutateArgs(jvmArgs);
 

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
@@ -12,6 +12,8 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.testing.Test;
 import org.javamodularity.moduleplugin.TestEngine;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
+import org.javamodularity.moduleplugin.extensions.TestModuleOptions;
 import org.javamodularity.moduleplugin.internal.TaskOption;
 
 import java.io.File;

--- a/src/test/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutatorTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutatorTest.java
@@ -6,6 +6,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
+import org.javamodularity.moduleplugin.extensions.PatchModuleExtension;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;

--- a/test-project-kotlin/greeter.api/build.gradle.kts
+++ b/test-project-kotlin/greeter.api/build.gradle.kts
@@ -1,5 +1,5 @@
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions
-import org.javamodularity.moduleplugin.tasks.TestModuleOptions
+import org.javamodularity.moduleplugin.extensions.TestModuleOptions
 
 //region NO-OP (DSL testing)
 tasks.compileJava {

--- a/test-project-kotlin/greeter.provider/build.gradle.kts
+++ b/test-project-kotlin/greeter.provider/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.javamodularity.moduleplugin.tasks.ModuleOptions
+import org.javamodularity.moduleplugin.extensions.ModuleOptions
 
 dependencies {
     implementation(project(":greeter.api"))

--- a/test-project-kotlin/greeter.provider/build.gradle.kts
+++ b/test-project-kotlin/greeter.provider/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.javamodularity.moduleplugin.extensions.ModuleOptions
+import org.javamodularity.moduleplugin.extensions.JavadocModuleOptions
 
 dependencies {
     implementation(project(":greeter.api"))
@@ -13,7 +13,7 @@ patchModules.config = listOf(
 )
 
 tasks.javadoc {
-    extensions.configure<ModuleOptions> {
+    extensions.configure<JavadocModuleOptions> {
         addModules = listOf("java.sql")
     }
 }

--- a/test-project-kotlin/greeter.runner/build.gradle.kts
+++ b/test-project-kotlin/greeter.runner/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.javamodularity.moduleplugin.tasks.ModuleOptions
+import org.javamodularity.moduleplugin.extensions.ModuleOptions
 
 plugins {
     application

--- a/test-project-kotlin/greeter.runner/build.gradle.kts
+++ b/test-project-kotlin/greeter.runner/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.javamodularity.moduleplugin.extensions.ModuleOptions
+import org.javamodularity.moduleplugin.extensions.RunModuleOptions
 
 plugins {
     application
@@ -24,7 +24,7 @@ patchModules.config = listOf(
 )
 
 (run) {
-    extensions.configure<ModuleOptions> {
+    extensions.configure<RunModuleOptions> {
         addModules = listOf("java.sql")
     }
 


### PR DESCRIPTION
Fixes #80:

> 1. Moving extensions from `tasks` subpackage to `extensions` subpackage
> 2. Extracting dedicated `*ModuleOptions` interfaces for every task
> 3. Limiting `ModuleOptions.addOpens` to `test` and `run` tasks only

> Note: (1) and (2) are *potentially breaking changes for Kotlin DSL*.

I'd prefer this to be merged without squashing if you agree.