### PR TITLE
Add dependencies on `compileModuleInfoJava` of dependent projects

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/internal/CompileModuleInfoHelper.java
+++ b/src/main/java/org/javamodularity/moduleplugin/internal/CompileModuleInfoHelper.java
@@ -1,0 +1,42 @@
+package org.javamodularity.moduleplugin.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public final class CompileModuleInfoHelper {
+
+    private static final Logger LOGGER = Logging.getLogger(CompileModuleInfoHelper.class);
+
+    /**
+     * If this project depends on projects that are using separate {@code module-info.java} compilation,
+     * {@code javaCompile} has to depend on {@code compileModuleInfoJava} of every such dependent project
+     * (otherwise, {@code module-info.java} of this project may not compile).
+     *
+     * @param javaCompile compile Java task to be modularized
+     */
+    public static void dependOnOtherCompileModuleInfoJavaTasks(JavaCompile javaCompile) {
+        dependentCompileModuleInfoJavaTaskStream(javaCompile.getProject())
+                .peek(compileModuleInfoJava -> LOGGER.debug("{}.dependsOn({})", javaCompile, compileModuleInfoJava))
+                .forEach(javaCompile::dependsOn);
+    }
+
+    /**
+     * @return a {@link Stream} of {@code compileModuleInfoJava} tasks from dependent projects
+     */
+    private static Stream<Task> dependentCompileModuleInfoJavaTaskStream(Project project) {
+        return project.getConfigurations().stream()
+                .flatMap(configuration -> configuration.getDependencies().stream())
+                .filter(dependency -> dependency instanceof ProjectDependency)
+                .map(dependency -> ((ProjectDependency) dependency).getDependencyProject().getTasks())
+                .map(tasks -> tasks.findByName(CompileModuleOptions.COMPILE_MODULE_INFO_TASK_NAME))
+                .filter(Objects::nonNull);
+    }
+}

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileModuleInfoTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileModuleInfoTask.java
@@ -7,6 +7,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
+import org.javamodularity.moduleplugin.internal.CompileModuleInfoHelper;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,6 +41,8 @@ public class CompileModuleInfoTask extends AbstractCompileTask {
     void configureModularityForCompileModuleInfoJava(
             JavaCompile compileJava, CompileModuleOptions moduleOptions) {
         JavaCompile compileModuleInfoJava = preconfigureCompileModuleInfoJava(compileJava);
+        CompileModuleInfoHelper.dependOnOtherCompileModuleInfoJavaTasks(compileModuleInfoJava);
+
         CompileJavaTaskMutator mutator = createCompileJavaTaskMutator(compileJava, moduleOptions);
 
         // don't convert to lambda: https://github.com/java9-modularity/gradle-modules-plugin/issues/54
@@ -50,12 +53,7 @@ public class CompileModuleInfoTask extends AbstractCompileTask {
             }
         });
 
-        project.getTasks().withType(Jar.class).configureEach(new Action<Jar>() {
-            @Override
-            public void execute(Jar jar) {
-                jar.from(helper().getModuleInfoDir());
-            }
-        });
+        project.getTasks().withType(Jar.class).configureEach(jar -> jar.from(helper().getModuleInfoDir()));
     }
 
     /**

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTask.java
@@ -7,6 +7,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
+import org.javamodularity.moduleplugin.internal.CompileModuleInfoHelper;
 
 import java.util.Optional;
 
@@ -45,6 +46,8 @@ public class CompileTask extends AbstractCompileTask {
      * @see CompileModuleInfoTask#configureModularityForCompileModuleInfoJava
      */
     void configureModularityForCompileJava(JavaCompile compileJava, CompileModuleOptions moduleOptions) {
+        CompileModuleInfoHelper.dependOnOtherCompileModuleInfoJavaTasks(compileJava);
+
         CompileJavaTaskMutator mutator = createCompileJavaTaskMutator(compileJava, moduleOptions);
         // don't convert to lambda: https://github.com/java9-modularity/gradle-modules-plugin/issues/54
         compileJava.doFirst(new Action<Task>() {


### PR DESCRIPTION
Fixes #107.

I haven't added any extra automated tests for it, but I have verified manually (by changing `LOGGER.debug` to `LOGGER.lifecycle`) that the dependencies are indeed being added as expected:

- for `test-project-groovy`:
```text
> Configure project :
Project :greeter.api => 'greeter.api' Java module
Project :greeter.javaexec => 'greeter.javaexec' Java module
Project :greeter.provider => 'greeter.provider' Java module
Project :greeter.provider.test => 'greeter.provider.test' Java module
Project :greeter.runner => 'greeter.runner' Java module
Project :greeter.startscripts => 'greeter.startscripts' Java module

> Configure project :greeter.javaexec
task ':greeter.javaexec:compileModuleInfoJava'.dependsOn(task ':greeter.api:compileModuleInfoJava')

> Configure project :greeter.provider
task ':greeter.provider:compileModuleInfoJava'.dependsOn(task ':greeter.api:compileModuleInfoJava')

> Configure project :greeter.provider.test
task ':greeter.provider.test:compileModuleInfoJava'.dependsOn(task ':greeter.api:compileModuleInfoJava')
task ':greeter.provider.test:compileModuleInfoJava'.dependsOn(task ':greeter.provider:compileModuleInfoJava')

> Configure project :greeter.runner
task ':greeter.runner:compileModuleInfoJava'.dependsOn(task ':greeter.api:compileModuleInfoJava')
task ':greeter.runner:compileModuleInfoJava'.dependsOn(task ':greeter.provider:compileModuleInfoJava')

> Configure project :greeter.startscripts
task ':greeter.startscripts:compileModuleInfoJava'.dependsOn(task ':greeter.api:compileModuleInfoJava')
task ':greeter.startscripts:compileModuleInfoJava'.dependsOn(task ':greeter.provider:compileModuleInfoJava')
```

- for `test-project-mixed`:
```text
> Configure project :
Project :greeter.api-jdk8 => 'greeter.api' Java module
Project :greeter.provider-jdk11 => 'greeter.provider' Java module
Project :greeter.provider-jdk11.test-jdk11 => 'greeter.provider.test' Java module
Project :greeter.provider-jdk8 => 'greeter.provider' Java module
Project :greeter.provider-jdk8.test-jdk11 => 'greeter.provider.test' Java module
Project :greeter.provider-jdk8.test-jdk8 => 'greeter.provider.test' Java module

> Configure project :greeter.provider-jdk11
task ':greeter.provider-jdk11:compileJava'.dependsOn(task ':greeter.api-jdk8:compileModuleInfoJava')

> Configure project :greeter.provider-jdk11.test-jdk11
task ':greeter.provider-jdk11.test-jdk11:compileJava'.dependsOn(task ':greeter.api-jdk8:compileModuleInfoJava')

> Configure project :greeter.provider-jdk8
task ':greeter.provider-jdk8:compileModuleInfoJava'.dependsOn(task ':greeter.api-jdk8:compileModuleInfoJava')

> Configure project :greeter.provider-jdk8.test-jdk11
task ':greeter.provider-jdk8.test-jdk11:compileJava'.dependsOn(task ':greeter.api-jdk8:compileModuleInfoJava')
task ':greeter.provider-jdk8.test-jdk11:compileJava'.dependsOn(task ':greeter.provider-jdk8:compileModuleInfoJava')

> Configure project :greeter.provider-jdk8.test-jdk8
task ':greeter.provider-jdk8.test-jdk8:compileModuleInfoJava'.dependsOn(task ':greeter.api-jdk8:compileModuleInfoJava')
task ':greeter.provider-jdk8.test-jdk8:compileModuleInfoJava'.dependsOn(task ':greeter.provider-jdk8:compileModuleInfoJava')
```