### PR TITLE
Adding support for additional test frameworks

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
+++ b/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
@@ -3,29 +3,38 @@ package org.javamodularity.moduleplugin;
 import org.gradle.api.Project;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public enum TestEngine {
 
-    JUNIT_4("junit", "junit", "junit", "junit"),
-    JUNIT_5("org.junit.jupiter", "junit-jupiter-api", "org.junit.jupiter.api", "org.junit.platform.commons"),
-    TESTNG("org.testng", "testng", "testng", "testng");
+    JUNIT_4("junit", "junit", "junit", "junit", ""),
+    JUNIT_5("org.junit.jupiter", "junit-jupiter-api", "org.junit.jupiter.api", "org.junit.platform.commons",
+            "org.junit.platform.commons/org.junit.platform.commons.util" +
+                    ",org.junit.platform.commons/org.junit.platform.commons.logging"),
+    TESTNG("org.testng", "testng", "testng", "testng", ""),
+    ASSERTJ("org.assertj", "assertj-core", "org.assertj.core", "org.assertj.core", ""),
+    MOCKITO("org.mockito", "mockito-core", "org.mockito", "org.mockito", ""),
+    EASYMOCK("org.easymock", "easymock", "org.easymock", "org.easymock", "");
 
     private final String groupId;
     private final String artifactId;
 
     public final String moduleName;
     public final String addOpens;
+    public final String addExports;
 
-    TestEngine(String groupId, String artifactId, String moduleName, String addOpens) {
+    TestEngine(String groupId, String artifactId, String moduleName, String addOpens, String addExports) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.moduleName = moduleName;
         this.addOpens = addOpens;
+        this.addExports = addExports;
     }
 
-    public static Optional<TestEngine> select(Project project) {
+    public static List<TestEngine> selectMultiple(Project project) {
         var configurations = project.getConfigurations();
         var testImplementation = configurations.getByName("testImplementation").getDependencies().stream();
         var testCompile = configurations.getByName("testCompile").getDependencies().stream();
@@ -33,7 +42,7 @@ public enum TestEngine {
                 .map(d -> TestEngine.select(d.getGroup(), d.getName()))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .findAny();
+                .collect(Collectors.toList());
     }
 
     private static Optional<TestEngine> select(String groupId, String artifactId) {

--- a/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
+++ b/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
@@ -10,28 +10,24 @@ import java.util.stream.Stream;
 
 public enum TestEngine {
 
-    JUNIT_4("junit", "junit", "junit", "junit", ""),
-    JUNIT_5("org.junit.jupiter", "junit-jupiter-api", "org.junit.jupiter.api", "org.junit.platform.commons",
-            "org.junit.platform.commons/org.junit.platform.commons.util" +
-                    ",org.junit.platform.commons/org.junit.platform.commons.logging"),
-    TESTNG("org.testng", "testng", "testng", "testng", ""),
-    ASSERTJ("org.assertj", "assertj-core", "org.assertj.core", "org.assertj.core", ""),
-    MOCKITO("org.mockito", "mockito-core", "org.mockito", "org.mockito", ""),
-    EASYMOCK("org.easymock", "easymock", "org.easymock", "org.easymock", "");
+    JUNIT_4("junit", "junit", "junit", "junit"),
+    JUNIT_5("org.junit.jupiter", "junit-jupiter-api", "org.junit.jupiter.api", "org.junit.platform.commons"),
+    TESTNG("org.testng", "testng", "testng", "testng"),
+    ASSERTJ("org.assertj", "assertj-core", "org.assertj.core", "org.assertj.core"),
+    MOCKITO("org.mockito", "mockito-core", "org.mockito", "org.mockito"),
+    EASYMOCK("org.easymock", "easymock", "org.easymock", "org.easymock");
 
     private final String groupId;
     private final String artifactId;
 
     public final String moduleName;
     public final String addOpens;
-    public final String addExports;
 
-    TestEngine(String groupId, String artifactId, String moduleName, String addOpens, String addExports) {
+    TestEngine(String groupId, String artifactId, String moduleName, String addOpens) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.moduleName = moduleName;
         this.addOpens = addOpens;
-        this.addExports = addExports;
     }
 
     public static List<TestEngine> selectMultiple(Project project) {

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
@@ -55,7 +55,7 @@ public class CompileTestTask extends AbstractModulePluginTask {
                 moduleName + "=" + helper().testSourceSet().getJava().getSourceDirectories().getAsPath()
         ).mutateArgs(compilerArgs);
 
-        TestEngine.select(project).ifPresent(testEngine -> {
+        TestEngine.selectMultiple(project).forEach(testEngine -> {
             new TaskOption("--add-modules", testEngine.moduleName).mutateArgs(compilerArgs);
             new TaskOption("--add-reads", moduleName + "=" + testEngine.moduleName).mutateArgs(compilerArgs);
         });

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
@@ -1,6 +1,5 @@
 package org.javamodularity.moduleplugin.tasks;
 
-import com.google.common.base.Strings;
 import org.codehaus.groovy.tools.Utilities;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -79,7 +78,6 @@ public class TestTask extends AbstractModulePluginTask {
         TestEngine.selectMultiple(project).forEach(testEngine -> {
             buildAddReadsOption(testEngine).mutateArgs(jvmArgs);
             buildAddOpensOptionStream(testEngine).forEach(option -> option.mutateArgs(jvmArgs));
-            buildAddExportsOptionStream(testEngine).forEach(option -> option.mutateArgs(jvmArgs));
         });
 
         ModuleInfoTestHelper.mutateArgs(project, jvmArgs::add);
@@ -116,13 +114,6 @@ public class TestTask extends AbstractModulePluginTask {
         return getPackages(testDirs).stream()
                 .map(packageName -> String.format("%s/%s=%s", moduleName, packageName, testEngine.addOpens))
                 .map(value -> new TaskOption("--add-opens", value));
-    }
-
-    private Stream<TaskOption> buildAddExportsOptionStream(TestEngine testEngine) {
-        return Arrays.stream(testEngine.addExports.split(","))
-                .filter(export -> !Strings.isNullOrEmpty(export))
-                .map(export -> String.format("%s=ALL-UNNAMED", export))
-                .map(value -> new TaskOption("--add-exports", value));
     }
 
     private static Set<String> getPackages(Collection<File> dirs) {

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -52,14 +52,16 @@ class ModulePluginSmokeTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"5.4.2", "5.5.2"})
-    void smokeTestJunit5(String junitVersion) {
-        var versionProperty = String.format("-PjUnitVersion=%s", junitVersion);
+    @ValueSource(strings = {"5.4.2/1.4.2", "5.5.2/1.5.2"})
+    void smokeTestJunit5(String junitVersionPair) {
+        var junitVersionParts = junitVersionPair.split("/");
+        var junitVersionProperty = String.format("-PjUnitVersion=%s", junitVersionParts[0]);
+        var junitPlatformVersionProperty = String.format("-PjUnitPlatformVersion=%s", junitVersionParts[1]);
         var result = GradleRunner.create()
                 .withProjectDir(new File("test-project/"))
                 .withPluginClasspath(pluginClasspath)
                 .withGradleVersion(GRADLE_VERSION)
-                .withArguments("-c", "smoke_test_settings.gradle", versionProperty, "clean", "build", "run", "--stacktrace")
+                .withArguments("-c", "smoke_test_settings.gradle", junitVersionProperty, junitPlatformVersionProperty, "clean", "build", "run", "--stacktrace")
                 .forwardOutput()
                 .build();
 

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -51,6 +51,24 @@ class ModulePluginSmokeTest {
         assertTasksSuccessful(result, "greeter.runner", "build", "run");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"5.4.2", "5.5.2"})
+    void smokeTestJunit5(String junitVersion) {
+        var versionProperty = String.format("-PjUnitVersion=%s", junitVersion);
+        var result = GradleRunner.create()
+                .withProjectDir(new File("test-project/"))
+                .withPluginClasspath(pluginClasspath)
+                .withGradleVersion(GRADLE_VERSION)
+                .withArguments("-c", "smoke_test_settings.gradle", versionProperty, "clean", "build", "run", "--stacktrace")
+                .forwardOutput()
+                .build();
+
+        assertTasksSuccessful(result, "greeter.api", "build");
+        assertTasksSuccessful(result, "greeter.provider", "build");
+        assertTasksSuccessful(result, "greeter.provider.test", "build");
+        assertTasksSuccessful(result, "greeter.runner", "build", "run");
+    }
+
     @Test
     void smokeTestMixed() throws IOException {
         var result = GradleRunner.create()

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -23,6 +23,7 @@ subprojects {
         testImplementation "org.junit.jupiter:junit-jupiter-api:$jUnitVersion"
         testImplementation "org.junit.jupiter:junit-jupiter-params:$jUnitVersion"
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$jUnitVersion"
+        testRuntimeOnly "org.junit.platform:junit-platform-launcher:$jUnitPlatformVersion"
     }
 
     build.dependsOn javadoc

--- a/test-project/build.gradle
+++ b/test-project/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.javamodularity.moduleplugin' version '1.5.0' apply false
+    id 'org.javamodularity.moduleplugin' version '1.6.0' apply false
 }
 
 subprojects {

--- a/test-project/gradle.properties
+++ b/test-project/gradle.properties
@@ -1,1 +1,1 @@
-jUnitVersion = 5.3.1
+jUnitVersion = 5.5.2

--- a/test-project/gradle.properties
+++ b/test-project/gradle.properties
@@ -1,1 +1,2 @@
 jUnitVersion = 5.5.2
+jUnitPlatformVersion = 1.5.2


### PR DESCRIPTION
Mockito, EasyMock, AssertJ, JUnit 5.5.x

This PR is meant to address two related issues:

1. The plugin doesn't work correctly with JUnit 5.5.x
2. The plugin is missing support for certain common testing components, and cannot accommodate multiple testing components being in scope at the same time

For example, JUnit 5 is designed to live comfortably in the same project with JUnit 4. Additionally, tools like Mockito, EasyMock, and AssertJ are commonly used.