### PR TITLE
Update README.md - Replace the legacy Buildscript block by Plugins (apply false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,8 @@ For this guide we assume the following directory structure:
 The main build file should look as follows:
 
 ```groovy
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "org.javamodularity:moduleplugin:1.6.0"
-  }
+plugins {
+    id 'org.javamodularity.moduleplugin' version '1.6.0' apply false
 }
 
 subprojects {


### PR DESCRIPTION
I propose a smaller and newer syntax for the plugin declaration in the demo code of the README.md.

Replace the legacy Buildscript block:
```groovy
buildscript {
  repositories {
    maven {
      url "https://plugins.gradle.org/m2/"
    }
  }
  dependencies {
    classpath "org.javamodularity:moduleplugin:1.6.0"
  }
}
```

 by Plugins (apply false):
```groovy
plugins {
    id 'org.javamodularity.moduleplugin' version '1.6.0' apply false
}
```

Available since gradle 4.10.
See https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl