### PR TITLE
Add support for JUnit 5 Params

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
+++ b/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
@@ -17,6 +17,7 @@ public enum TestEngine {
     JUNIT_5("org.junit.jupiter", "junit-jupiter", "org.junit.jupiter.api", "org.junit.jupiter.api"),
     TESTNG("org.testng", "testng", "testng", "testng"),
     ASSERTJ("org.assertj", "assertj-core", "org.assertj.core", "org.assertj.core"),
+    TRUTH("com.google.truth", "truth", "truth", "truth"),
     MOCKITO("org.mockito", "mockito-core", "org.mockito", "org.mockito"),
     EASYMOCK("org.easymock", "easymock", "org.easymock", "org.easymock"),
     SPOCK("org.spockframework", "spock-core", "org.spockframework.core", "org.spockframework.core",

--- a/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
+++ b/src/main/java/org/javamodularity/moduleplugin/TestEngine.java
@@ -13,6 +13,7 @@ public enum TestEngine {
 
     JUNIT_4("junit", "junit", "junit", "junit"),
     JUNIT_5_API("org.junit.jupiter", "junit-jupiter-api", "org.junit.jupiter.api", "org.junit.platform.commons"),
+    JUNIT_5_PARAMS("org.junit.jupiter", "junit-jupiter-params", "org.junit.jupiter.params", "org.junit.platform.commons"),
     JUNIT_5("org.junit.jupiter", "junit-jupiter", "org.junit.jupiter.api", "org.junit.jupiter.api"),
     TESTNG("org.testng", "testng", "testng", "testng"),
     ASSERTJ("org.assertj", "assertj-core", "org.assertj.core", "org.assertj.core"),


### PR DESCRIPTION
Add support for automatically detecting a JUnit 5 Parameters dependency and configuring the test configurations accordingly.

Fixes #175