### PR TITLE
issue #192: Plugin build fails with Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ shadowJar {
 jar.enabled = false
 jar.dependsOn shadowJar
 
+processResources.duplicatesStrategy = 'exclude'
+
 configurations {
     [apiElements, runtimeElements].each {
         it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }


### PR DESCRIPTION
This PR just sets a `duplicatesStrategy = 'exclude'` to deal with the issue.