### PR TITLE
Resolve warning in Gradle 7.2

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileModuleInfoTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileModuleInfoTask.java
@@ -55,17 +55,25 @@ public class CompileModuleInfoTask extends AbstractCompileTask {
             }
         });
 
-        project.getTasks().withType(Jar.class).configureEach(jar -> {
-            File moduleInfoDir = helper().getModuleInfoDir();
-            jar.from(moduleInfoDir);
-            jar.doFirst(task -> {
-                File classesDir = helper().mainSourceSet().getJava().getOutputDir();
-                File mainModuleInfoFile = new File(classesDir, "module-info.class");
-                File customModuleInfoFile = new File(moduleInfoDir, "module-info.class");
-                if(mainModuleInfoFile.isFile() && customModuleInfoFile.isFile()) {
-                    mainModuleInfoFile.delete();
-                }
-            });
+        // don't convert to lambda: https://docs.gradle.org/7.2/userguide/validation_problems.html#implementation_unknown
+        project.getTasks().withType(Jar.class).configureEach(new Action<Jar>() {
+            @Override
+            public void execute(Jar jar) {
+                File moduleInfoDir = CompileModuleInfoTask.this.helper().getModuleInfoDir();
+                jar.from(moduleInfoDir);
+                // don't convert to lambda: https://docs.gradle.org/7.2/userguide/validation_problems.html#implementation_unknown
+                jar.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        File classesDir = CompileModuleInfoTask.this.helper().mainSourceSet().getJava().getOutputDir();
+                        File mainModuleInfoFile = new File(classesDir, "module-info.class");
+                        File customModuleInfoFile = new File(moduleInfoDir, "module-info.class");
+                        if (mainModuleInfoFile.isFile() && customModuleInfoFile.isFile()) {
+                            mainModuleInfoFile.delete();
+                        }
+                    }
+                });
+            }
         });
     }
 

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -199,7 +199,7 @@ class ModulePluginSmokeTest {
 
     @CartesianProductTest(name = "smokeTestRunDemo({arguments})")
     @CartesianValueSource(strings = {"test-project", "test-project-kotlin", "test-project-groovy"})
-    @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0"})
+    @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0", "7.2"})
     void smokeTestRunDemo(String projectName, String gradleVersion) {
         LOGGER.info("Executing smokeTestRunDemo with Gradle {}", gradleVersion);
         var result = GradleRunner.create()
@@ -212,6 +212,7 @@ class ModulePluginSmokeTest {
                 .build();
 
         assertTasksSuccessful(result, "greeter.javaexec", "runDemo1", "runDemo2");
+        assertFalse(result.getOutput().contains("Using Java lambdas is not supported as task inputs"));
     }
 
     @CartesianProductTest(name = "smokeTestRunStartScripts({arguments})")


### PR DESCRIPTION
Hello 👋 
Thanks for providing this Gradle plugin, it helps me a lot to keep build scripts simple even with module support. Here I have a suggestion to support Gradle 7.2:

I'm using the gradle-modules-plugin with Gradle 7.2, and found the [following warnings during the build](https://github.com/jspecify/jspecify/runs/3443340180#step:6:36):

```
Execution optimizations have been disabled for task ':jar' to ensure correctness due to the following reasons:
  - Additional action of task ':jar' was implemented by the Java lambda 'org.javamodularity.moduleplugin.tasks.CompileModuleInfoTask$$Lambda$813/0x0000000100832c40'. Reason: Using Java lambdas is not supported as task inputs. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implementation_unknown for more details about this problem.
```

This issue is similar to #54 but totally new in Gradle 7.2. Official solution for this issue is simply replacing lambdas with anonymous internal `Action` classes, so I'm suggesting these change.

Thanks for checking this PR!