### PR TITLE
Replace usage of outdated Gradle API

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileModuleInfoTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileModuleInfoTask.java
@@ -59,7 +59,15 @@ public class CompileModuleInfoTask extends AbstractCompileTask {
             File moduleInfoDir = helper().getModuleInfoDir();
             jar.from(moduleInfoDir);
             jar.doFirst(task -> {
-                File classesDir = helper().mainSourceSet().getJava().getOutputDir();
+                File classesDir;
+                if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {
+                    // SourceDirectorySet#getClassesDirectory() is supported from Gradle 6.1
+                    // https://docs.gradle.org/6.1/javadoc/org/gradle/api/file/SourceDirectorySet.html#getClassesDirectory--
+                    classesDir = helper().mainSourceSet().getJava().getClassesDirectory().get().getAsFile();
+                } else {
+                    classesDir = helper().mainSourceSet().getJava().getOutputDir();
+                }
+
                 File mainModuleInfoFile = new File(classesDir, "module-info.class");
                 File customModuleInfoFile = new File(moduleInfoDir, "module-info.class");
                 if(mainModuleInfoFile.isFile() && customModuleInfoFile.isFile()) {
@@ -82,7 +90,13 @@ public class CompileModuleInfoTask extends AbstractCompileTask {
         compileModuleInfoJava.setSource(pathToModuleInfoJava());
         compileModuleInfoJava.getOptions().setSourcepath(project.files(pathToModuleInfoJava().getParent()));
 
-        compileModuleInfoJava.setDestinationDir(helper().getModuleInfoDir());
+        if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {
+            // AbstractCompile#getDestinationDirectory() is supported from Gradle 6.1
+            // https://docs.gradle.org/6.1/javadoc/org/gradle/api/tasks/compile/AbstractCompile.html#getDestinationDirectory--
+            compileModuleInfoJava.getDestinationDirectory().set(helper().getModuleInfoDir());
+        } else {
+            compileModuleInfoJava.setDestinationDir(helper().getModuleInfoDir());
+        }
 
         // we need all the compiled classes before compiling module-info.java
         compileModuleInfoJava.dependsOn(compileJava);

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -38,7 +38,7 @@ class ModulePluginSmokeTest {
 
     @CartesianProductTest(name = "smokeTest({arguments})")
     @CartesianValueSource(strings = {"test-project", "test-project-kotlin", "test-project-groovy"})
-    @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0"})
+    @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0", "7.1", "7.2"})
     void smokeTest(String projectName, String gradleVersion) {
         LOGGER.info("Executing smokeTest with Gradle {}", gradleVersion);
         var result = GradleRunner.create()


### PR DESCRIPTION
Currently there are several dependencies on deprecated API. Gradle 6.1 and 7.1 provide better replacements, so this PR suggests introducing these APIs.
