### PR TITLE
ci: Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: 11
         cache: gradle
+        distribution: microsoft
+        java-version: 11
     - name: Build with Gradle
       run: ./gradlew build --scan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,16 +8,10 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v2
-    - name: Configure Gradle cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        cache: gradle
     - name: Build with Gradle
       run: ./gradlew build --scan

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,17 +11,11 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v2
-    - name: Configure Gradle cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        cache: gradle
     - name: Create gradle.properties
       run: echo -e "gradle.publish.key=$GRADLE_PUBLISH_KEY\ngradle.publish.secret=$GRADLE_PUBLISH_SECRET" > gradle.properties
     - name: Build with Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,9 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: 11
         cache: gradle
+        distribution: microsoft
+        java-version: 11
     - name: Create gradle.properties
       run: echo -e "gradle.publish.key=$GRADLE_PUBLISH_KEY\ngradle.publish.secret=$GRADLE_PUBLISH_SECRET" > gradle.properties
     - name: Build with Gradle


### PR DESCRIPTION
Hello folks,

I want to suggest this PR which introduces major updates to GitHub Actions used in the workflow:

1. [`actions/checkout` released v3](https://github.com/actions/checkout/releases/tag/v3.0.0) which is using the latest Node.JS as its default runtime. Current Node.JS in runtime is [v12, which will be EOL at this April](https://nodejs.org/en/about/releases/), so better to update it.
2. `actions/setup-java` released v2 which supports the [dependency caching](https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/). It lets us remove the `actions/cache` from the workflow, and make the workflow definition simple and short.

Hope that this PR helps you to keep the development environment updated and secure! :)