### PR TITLE
Provide better support for toolchains for JVM projects

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/extensions/DefaultModularityExtension.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/DefaultModularityExtension.java
@@ -4,7 +4,6 @@ import java.util.List;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.compile.JavaCompile;

--- a/test-project/greeter.toolchain/build.gradle
+++ b/test-project/greeter.toolchain/build.gradle
@@ -1,7 +1,7 @@
 //region NO-OP (DSL testing)
 
 // one of the supported Java version (prefer LTS version)
-def toolchainVer = 17
+def toolchainVer = 11
 
 java {
     toolchain {

--- a/test-project/greeter.toolchain/build.gradle
+++ b/test-project/greeter.toolchain/build.gradle
@@ -1,0 +1,18 @@
+//region NO-OP (DSL testing)
+
+// one of the supported Java version (prefer LTS version)
+def toolchainVer = 17
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(toolchainVer))
+    }
+}
+
+modularity {
+    // This version should be less than `toolchainVer` because:
+    // * if the version is same to `toolchainVer` we cannot reproduce the existing problem
+    // * if the version is greather than `toolchainVer` javac cannot create class files
+    standardJavaRelease(9)
+}
+//endregion

--- a/test-project/greeter.toolchain/src/main/java/examples/greeter/api/Greeter.java
+++ b/test-project/greeter.toolchain/src/main/java/examples/greeter/api/Greeter.java
@@ -1,0 +1,5 @@
+package examples.greeter.api;
+
+public interface Greeter {
+    String hello();
+}

--- a/test-project/greeter.toolchain/src/main/java/module-info.java
+++ b/test-project/greeter.toolchain/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module greeter.api {
+    exports examples.greeter.api;
+}

--- a/test-project/settings.gradle
+++ b/test-project/settings.gradle
@@ -16,6 +16,6 @@ include 'greeter.runner'
 include 'greeter.javaexec'
 include 'greeter.startscripts'
 
-if(GradleVersion.current().compareTo(GradleVersion.version("6.7")) >= 0) {
+if(GradleVersion.current().compareTo(GradleVersion.version("6.6")) >= 0) {
     include 'greeter.toolchain'
 }

--- a/test-project/settings.gradle
+++ b/test-project/settings.gradle
@@ -15,3 +15,7 @@ include 'greeter.runner'
 
 include 'greeter.javaexec'
 include 'greeter.startscripts'
+
+if(GradleVersion.current().compareTo(GradleVersion.version("6.7")) >= 0) {
+    include 'greeter.toolchain'
+}


### PR DESCRIPTION
Gradle 6.7+ provides the [Toolchains for JVM projects](https://docs.gradle.org/7.4/userguide/toolchains.html), which makes it possible to specify which Java we use to compile the project. refs #187

Currently gradle-modules-plugin has two potential problems around this toolchain feature:

1. By default the toolchain feature adds the `--release` option via `javaCompile.options.release` property, and it conflicts with the `--release` option set by this plugin. Fixed by the commit 6163723598d0bd5ff0748672507cd934b169718f
```
* What went wrong:
Execution failed for task :greeter.toolchain:compileJava.
> Cannot specify --release via `CompileOptions.compilerArgs` when using `JavaCompile.release`.
```

2. When a toolchain is enabled, the version of java compiler will be not the version of JVM running Gradle, but the version of JVM set via toolchain. So we should refer properties of the `JavaToolchainSpec` instead of `JavaVersion.current()`. Fixed by the commit 68ed16f00ddd18a404c8c5e2633082a3c91ecf88
```
* What went wrong:
A problem occurred configuring project ':greeter.toolchain'.
> sourceCompatibility should not be set together with --release option
```

Based on the ["Testing locally published plugin" guideline](https://github.com/java9-modularity/gradle-modules-plugin/tree/48f4b4df1156c48669294957b34b8450e4c50841/test-project#testing-locally-published-plugin), I've confirmed that problems reproduced by the newly added test project have been resolved by these two commits.

Thanks for checking my PR! 🙌 