### PR TITLE
Fix for Kotlin 1.7 breaking changes

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileJavaTaskMutator.java
@@ -4,12 +4,12 @@ import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.javamodularity.moduleplugin.JavaProjectHelper;
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
 import org.javamodularity.moduleplugin.extensions.PatchModuleContainer;
 import org.javamodularity.moduleplugin.internal.MutatorHelper;
+import org.javamodularity.moduleplugin.tasks.MergeClassesHelper.CompileTaskWrapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +60,7 @@ class CompileJavaTaskMutator {
                 helper().modularityExtension().optionContainer().getPatchModuleContainer());
         String moduleName = helper().moduleName();
         new MergeClassesHelper(project).otherCompileTaskStream()
-                .map(AbstractCompile::getDestinationDir)
+                .map(CompileTaskWrapper::getDestinationDir)
                 .forEach(dir -> patchModuleContainer.addDir(moduleName, dir.getAbsolutePath()));
 
         // Keep only valid module-path entries (https://github.com/java9-modularity/gradle-modules-plugin/issues/190)

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesHelper.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesHelper.java
@@ -1,6 +1,8 @@
 package org.javamodularity.moduleplugin.tasks;
 
 import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
@@ -15,10 +17,13 @@ import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
 import org.javamodularity.moduleplugin.internal.StreamHelper;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class MergeClassesHelper {
@@ -38,10 +43,11 @@ public class MergeClassesHelper {
         return project;
     }
 
-    public Stream<AbstractCompile> otherCompileTaskStream() {
+    public Stream<CompileTaskWrapper> otherCompileTaskStream() {
         return otherCompileTaskNameStream()
-                .map(name -> helper().findTask(name, AbstractCompile.class))
-                .flatMap(Optional::stream);
+                .map(name -> helper().findTask(name, Task.class))
+                .flatMap(Optional::stream)
+                .map(this::toWrapper);
     }
 
     private Stream<String> otherCompileTaskNameStream() {
@@ -52,16 +58,16 @@ public class MergeClassesHelper {
         );
     }
 
-    public JavaCompile javaCompileTask() {
-        return helper().task(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaCompile.class);
+    private CompileTaskWrapper javaCompileTask() {
+        return toWrapper(helper().task(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaCompile.class));
     }
 
-    public Stream<AbstractCompile> allCompileTaskStream() {
+    public Stream<CompileTaskWrapper> allCompileTaskStream() {
         return Stream.concat(Stream.of(javaCompileTask()), otherCompileTaskStream());
     }
 
     public boolean isMergeRequired() {
-        return otherCompileTaskStream().anyMatch(task -> !task.getSource().isEmpty());
+        return otherCompileTaskStream().anyMatch(CompileTaskWrapper::hasSource);
     }
 
     public Sync createMergeClassesTask() {
@@ -84,12 +90,112 @@ public class MergeClassesHelper {
         }
 
         Set<File> files = new HashSet<>(classpath.getFiles());
-        allCompileTaskStream().map(AbstractCompile::getDestinationDir).forEach(files::remove);
+        allCompileTaskStream().map(CompileTaskWrapper::getDestinationDir).forEach(files::remove);
         files.add(helper().getMergedDir());
         return project.files(files.toArray());
     }
 
+    private CompileTaskWrapper toWrapper(Task task) {
+        return task instanceof AbstractCompile
+            ? new GradleTaskWrapper((AbstractCompile) task)
+            : new ReflectionTaskWrapper(task);
+    }
+
     private JavaProjectHelper helper() {
         return new JavaProjectHelper(project);
+    }
+
+    public interface CompileTaskWrapper {
+        Task getTask();
+
+        File getDestinationDir();
+
+        boolean hasSource();
+    }
+
+    private static final class GradleTaskWrapper implements CompileTaskWrapper {
+
+        private final AbstractCompile task;
+
+        GradleTaskWrapper(AbstractCompile task) {
+            this.task = task;
+        }
+
+        @Override
+        public Task getTask() {
+            return task;
+        }
+
+        @Override
+        public File getDestinationDir() {
+            return task.getDestinationDir();
+        }
+
+        @Override
+        public boolean hasSource() {
+            return !task.getSource().isEmpty();
+        }
+    }
+
+    private static final class ReflectionTaskWrapper implements CompileTaskWrapper {
+
+        private final Task task;
+        private final Supplier<DirectoryProperty> destinationDir;
+        private final Supplier<FileCollection> source;
+
+        ReflectionTaskWrapper(Task task) {
+            this.task = task;
+            this.destinationDir = supplier(
+                    task,
+                    "getDestinationDirectory",
+                    DirectoryProperty.class
+            );
+            this.source = supplier(
+                    task,
+                    "getSources",
+                    FileCollection.class
+            );
+        }
+
+        @Override
+        public Task getTask() {
+            return task;
+        }
+
+        @Override
+        public File getDestinationDir() {
+            return destinationDir.get().getAsFile().getOrNull();
+        }
+
+        @Override
+        public boolean hasSource() {
+            return !source.get().isEmpty();
+        }
+
+        private static <T> Supplier<T> supplier(Task task, String getterName, Class<T> getterReturnType) {
+            final Method m = getMethod(task, getterName);
+
+            return () -> {
+                try {
+                    final Object result = m.invoke(task);
+                    return getterReturnType.cast(result);
+                } catch (InvocationTargetException e) {
+                    if (e.getTargetException() instanceof RuntimeException) {
+                        throw (RuntimeException) e.getTargetException();
+                    }
+                    throw new RuntimeException(e.getTargetException());
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("Failed to invoke " + getterName + " on " + task.getClass(), e);
+                }
+            };
+        }
+
+        private static Method getMethod(Task task, String name) {
+            try {
+                return task.getClass().getMethod(name);
+            } catch (NoSuchMethodException e) {
+                throw new IllegalStateException("Method " + name + " missing on " + task.getClass(), e);
+            }
+        }
     }
 }

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesTask.java
@@ -26,14 +26,14 @@ public class MergeClassesTask extends AbstractModulePluginTask {
     public void configureMergeClassesAfterEvaluate() {
         var mergeClasses = mergeClassesHelper().createMergeClassesTask();
 
-        mergeClassesHelper().allCompileTaskStream().forEach(task -> {
+        mergeClassesHelper().allCompileTaskStream().forEach(taskWrapper -> {
             List<String> modularTasks = List.of(JavaPlugin.COMPILE_JAVA_TASK_NAME, CompileModuleOptions.COMPILE_MODULE_INFO_TASK_NAME);
-            if(modularTasks.contains(task.getName())) {
-                mergeClasses.from(task.getDestinationDir());
+            if(modularTasks.contains(taskWrapper.getTask().getName())) {
+                mergeClasses.from(taskWrapper.getDestinationDir());
             } else {
-                mergeClasses.from(task.getDestinationDir(), copySpec -> copySpec.exclude("**/module-info.class"));
+                mergeClasses.from(taskWrapper.getDestinationDir(), copySpec -> copySpec.exclude("**/module-info.class"));
             }
-            mergeClasses.dependsOn(task);
+            mergeClasses.dependsOn(taskWrapper.getTask());
         });
         mergeClasses.into(helper().getMergedDir());
         mergeClasses.onlyIf(task -> mergeClassesHelper().isMergeRequired());

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -37,7 +37,7 @@ class ModulePluginSmokeTest {
     }
 
     @CartesianProductTest(name = "smokeTest({arguments})")
-    @CartesianValueSource(strings = {"test-project", "test-project-kotlin", "test-project-groovy"})
+    @CartesianValueSource(strings = {"test-project", "test-project-kotlin-pre-1-7", "test-project-kotlin", "test-project-groovy"})
     @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0", "7.2"})
     void smokeTest(String projectName, String gradleVersion) {
         LOGGER.lifecycle("Executing smokeTest of {} with Gradle {}", projectName, gradleVersion);
@@ -60,7 +60,7 @@ class ModulePluginSmokeTest {
     }
 
     @CartesianProductTest(name = "smokeTestRun({arguments})")
-    @CartesianValueSource(strings = {"test-project", "test-project-kotlin", "test-project-groovy"})
+    @CartesianValueSource(strings = {"test-project", "test-project-kotlin-pre-1-7", "test-project-kotlin", "test-project-groovy"})
     @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0", "7.2"})
     void smokeTestRun(String projectName, String gradleVersion) {
         LOGGER.lifecycle("Executing smokeTestRun of {} with Gradle {}", projectName, gradleVersion);
@@ -158,7 +158,7 @@ class ModulePluginSmokeTest {
     }
 
     @CartesianProductTest(name = "smokeTestDist({arguments})")
-    @CartesianValueSource(strings = {"test-project", "test-project-kotlin", "test-project-groovy"})
+    @CartesianValueSource(strings = {"test-project", "test-project-kotlin-pre-1-7", "test-project-kotlin", "test-project-groovy"})
     @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0", "7.2"})
     void smokeTestDist(String projectName, String gradleVersion) {
         LOGGER.lifecycle("Executing smokeTestDist of {} with Gradle {}", projectName, gradleVersion);
@@ -199,7 +199,7 @@ class ModulePluginSmokeTest {
     }
 
     @CartesianProductTest(name = "smokeTestRunDemo({arguments})")
-    @CartesianValueSource(strings = {"test-project", "test-project-kotlin", "test-project-groovy"})
+    @CartesianValueSource(strings = {"test-project", "test-project-kotlin-pre-1-7", "test-project-kotlin", "test-project-groovy"})
     @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0", "7.2"})
     void smokeTestRunDemo(String projectName, String gradleVersion) {
         LOGGER.lifecycle("Executing smokeTestRunDemo of {} with Gradle {}", projectName, gradleVersion);
@@ -218,7 +218,7 @@ class ModulePluginSmokeTest {
     }
 
     @CartesianProductTest(name = "smokeTestRunStartScripts({arguments})")
-    @CartesianValueSource(strings = {"test-project", "test-project-kotlin", "test-project-groovy"})
+    @CartesianValueSource(strings = {"test-project", "test-project-kotlin-pre-1-7", "test-project-kotlin", "test-project-groovy"})
     @CartesianValueSource(strings = {"5.1", "5.6", "6.3", "6.4.1", "6.5.1", "6.8.3", "7.0", "7.2"})
     void smokeTestRunStartScripts(String projectName, String gradleVersion) {
         LOGGER.lifecycle("Executing smokeTestRunScripts of {} with Gradle {}", projectName, gradleVersion);
@@ -248,7 +248,9 @@ class ModulePluginSmokeTest {
     }
 
     private static boolean checkCombination(String projectName, String gradleVersion) {
-        if(projectName.equals("test-project-kotlin") && gradleVersion.compareTo("6.4") < 0) {
+        final boolean kotlin_NotSupported = projectName.startsWith("test-project-kotlin") && gradleVersion.compareTo("6.4") < 0;
+        final boolean kotlin1_7_NotSupported = projectName.equals("test-project-kotlin") && gradleVersion.compareTo("6.6") < 0;
+        if (kotlin_NotSupported || kotlin1_7_NotSupported) {
             LOGGER.lifecycle("Unsupported combination: {} / Gradle {}. Test skipped", projectName, gradleVersion);
             return false;
         }

--- a/test-project-kotlin-pre-1-7/README.md
+++ b/test-project-kotlin-pre-1-7/README.md
@@ -1,0 +1,40 @@
+Introduction
+===
+
+This Kotlin test project can be used as a standalone test project to verify the published plugin.
+It is also used as an internal test project for testing unpublished plugin changes.
+
+Standalone test product
+===
+To run this product as a standalone test product use this command (launched from `test-project-kotlin` directory):
+```
+../gradlew clean build
+```
+
+It will use the most recent plugin version from Gradle maven repository to compile the test project with
+modules and run the unit tests.
+
+Testing locally published plugin
+===
+
+You can publish the plugin locally by running this command from the root directory:
+
+`./gradlew publishToMavenLocal`
+
+You can test the locally published plugin by running the following command from `test-project-kotlin` directory.
+
+`../gradlew -c local_maven_settings.gradle clean build` 
+
+It will use the locally published version of the plugin to compile the test project with 
+modules and run the unit tests.
+
+
+Internal test project
+===
+
+This mode is enabled in `ModulePluginSmokeTest` by passing an extra parameter (`-c smoke_test_settings.gradle`).
+`smoke_test_settings.gradle` script configures plugin management for `build.gradle.kts` so that the plugin cannot be resolved from
+a Gradle plugin repository. Instead, it relies on the smoke test to make the plugin under development available
+to the test project by sharing a classpath (using Gradle TestKit).
+
+__CAUTION:__ This approach won't work outside of the smoke test, it will break the build because the plugin jar won't be resolved.

--- a/test-project-kotlin-pre-1-7/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.7.10" apply false
+    kotlin("jvm") version "1.3.72" apply false
     id("org.javamodularity.moduleplugin") version "1.8.11" apply false
 }
 

--- a/test-project-kotlin-pre-1-7/gradle.properties
+++ b/test-project-kotlin-pre-1-7/gradle.properties
@@ -1,0 +1,2 @@
+jUnitVersion = 5.6.2
+jUnitPlatformVersion = 1.6.2

--- a/test-project-kotlin-pre-1-7/greeter.api/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/greeter.api/build.gradle.kts
@@ -1,0 +1,21 @@
+import org.javamodularity.moduleplugin.extensions.CompileModuleOptions
+import org.javamodularity.moduleplugin.extensions.TestModuleOptions
+
+//region NO-OP (DSL testing)
+tasks.compileJava {
+    extensions.configure<CompileModuleOptions> {
+        addModules = listOf()
+        compileModuleInfoSeparately = false
+    }
+}
+
+tasks.test {
+    extensions.configure<TestModuleOptions> {
+        addModules = listOf()
+        runOnClasspath = false
+    }
+}
+
+modularity {
+}
+//endregion

--- a/test-project-kotlin-pre-1-7/greeter.api/src/main/java/module-info.java
+++ b/test-project-kotlin-pre-1-7/greeter.api/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module greeter.api {
+    exports examples.greeter.api;
+    requires kotlin.stdlib;
+}

--- a/test-project-kotlin-pre-1-7/greeter.api/src/main/kotlin/examples/greeter/api/Greeter.kt
+++ b/test-project-kotlin-pre-1-7/greeter.api/src/main/kotlin/examples/greeter/api/Greeter.kt
@@ -1,0 +1,5 @@
+package examples.greeter.api
+
+interface Greeter {
+    fun hello(): String
+}

--- a/test-project-kotlin-pre-1-7/greeter.javaexec/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/greeter.javaexec/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.javamodularity.moduleplugin.tasks.ModularJavaExec
+
+val moduleName: String by project
+
+dependencies {
+    implementation(project(":greeter.api"))
+    runtimeOnly(project(":greeter.provider"))
+}
+
+patchModules.config = listOf(
+        "java.annotation=jsr305-3.0.2.jar"
+)
+modularity {
+    patchModule("java.annotation", "jsr250-api-1.0.jar")
+}
+
+File("${project.projectDir}/src/main/kotlin/demo")
+        .listFiles({ _, name -> Regex("Demo.*\\.kt") matches name })
+        .forEach { file ->
+            val demoClassName = file.name.removeSuffix(".kt")
+            tasks.create<ModularJavaExec>("run$demoClassName") {
+                group = "Demo"
+                description = "Run the $demoClassName program"
+                mainClass.set("demo.${demoClassName}Kt")
+                mainModule.set(moduleName)
+                jvmArgs = listOf("-Xmx128m")
+            }
+        }

--- a/test-project-kotlin-pre-1-7/greeter.javaexec/src/main/java/module-info.java
+++ b/test-project-kotlin-pre-1-7/greeter.javaexec/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+import examples.greeter.api.Greeter;
+
+module greeter.javaexec {
+    requires greeter.api;
+    requires kotlin.stdlib;
+
+    uses Greeter;
+}

--- a/test-project-kotlin-pre-1-7/greeter.javaexec/src/main/kotlin/demo/Demo1.kt
+++ b/test-project-kotlin-pre-1-7/greeter.javaexec/src/main/kotlin/demo/Demo1.kt
@@ -1,0 +1,12 @@
+package demo
+
+import examples.greeter.api.Greeter
+
+import java.util.ServiceLoader
+
+fun main(args: Array<String>) {
+    val greeter = ServiceLoader.load(Greeter::class.java)
+            .findFirst()
+            .orElseThrow{RuntimeException("No Greeter found!")}
+    println("Demo1: " + greeter.hello())
+}

--- a/test-project-kotlin-pre-1-7/greeter.javaexec/src/main/kotlin/demo/Demo2.kt
+++ b/test-project-kotlin-pre-1-7/greeter.javaexec/src/main/kotlin/demo/Demo2.kt
@@ -1,0 +1,12 @@
+package demo
+
+import examples.greeter.api.Greeter
+
+import java.util.ServiceLoader
+
+fun main(args: Array<String>) {
+    val greeter = ServiceLoader.load(Greeter::class.java)
+            .findFirst()
+            .orElseThrow { RuntimeException("No Greeter found!") }
+    println("Demo2: " + greeter.hello())
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.test/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/greeter.provider.test/build.gradle.kts
@@ -1,0 +1,13 @@
+dependencies {
+    implementation(project(":greeter.api"))
+    runtimeOnly(project(":greeter.provider"))
+}
+
+modularity {
+    patchModule("java.annotation", "jsr305-3.0.2.jar")
+    patchModule("java.annotation", "jsr250-api-1.0.jar")
+}
+
+val compileTestJava: JavaCompile by tasks.named("compileTestJava")
+val moduleOptions: org.javamodularity.moduleplugin.extensions.ModuleOptions by compileTestJava.extensions
+moduleOptions.addModules = listOf("jdk.unsupported")

--- a/test-project-kotlin-pre-1-7/greeter.provider.test/src/main/java/module-info.java
+++ b/test-project-kotlin-pre-1-7/greeter.provider.test/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+import examples.greeter.api.Greeter;
+
+module greeter.provider.test {
+    requires greeter.api;
+    requires kotlin.stdlib;
+    uses Greeter;
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.test/src/main/kotlin/tests/GreeterLocator.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider.test/src/main/kotlin/tests/GreeterLocator.kt
@@ -1,0 +1,13 @@
+package tests
+
+import examples.greeter.api.Greeter
+
+import java.util.ServiceLoader
+
+class GreeterLocator {
+    fun findGreeter(): Greeter {
+        return ServiceLoader.load(Greeter::class.java)
+                .findFirst()
+                .orElseThrow{RuntimeException("No Greeter found")}
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.test/src/test/kotlin/tests/GreeterTest.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider.test/src/test/kotlin/tests/GreeterTest.kt
@@ -1,0 +1,13 @@
+package tests
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.assertFalse
+
+class GreeterTest {
+    @Test
+    fun testLocate() {
+        val greeter = GreeterLocator().findGreeter()
+        assertFalse(greeter.hello().isBlank())
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.testfixture/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/greeter.provider.testfixture/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `java-test-fixtures`
+}
+
+//// Include the main sourceset as a dependency of testFixtures.
+//kotlin.target.compilations.getByName("testFixtures") {
+//    associateWith(target.compilations.getByName("main"))
+//}
+
+dependencies {
+    implementation(project(":greeter.api"))
+    testFixturesImplementation(project(":greeter.api"))
+    runtimeOnly(project(":greeter.provider"))
+}
+
+modularity {
+    patchModule("java.annotation", "jsr305-3.0.2.jar")
+    patchModule("java.annotation", "jsr250-api-1.0.jar")
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/main/java/module-info.java
+++ b/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+import examples.greeter.api.Greeter;
+
+module greeter.provider.testfixture {
+    requires greeter.api;
+    requires kotlin.stdlib;
+    uses Greeter;
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/main/kotlin/testfixture/GreeterLocator.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/main/kotlin/testfixture/GreeterLocator.kt
@@ -1,0 +1,13 @@
+package testfixture
+
+import examples.greeter.api.Greeter
+
+import java.util.ServiceLoader
+
+class GreeterLocator {
+    fun findGreeter(): Greeter {
+        return ServiceLoader.load(Greeter::class.java)
+                .findFirst()
+                .orElseThrow{RuntimeException("No Greeter found")}
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/test/kotlin/testfixture/GreeterTest.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/test/kotlin/testfixture/GreeterTest.kt
@@ -1,0 +1,13 @@
+package testfixture
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.assertFalse
+
+class GreeterTest: GreeterFixture() {
+    @Test
+    fun testLocate() {
+        val greeter = locator().findGreeter()
+        assertFalse(greeter.hello().isBlank())
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/testFixtures/kotlin/testfixture/GreeterFixture.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider.testfixture/src/testFixtures/kotlin/testfixture/GreeterFixture.kt
@@ -1,0 +1,5 @@
+package testfixture
+
+open class GreeterFixture {
+    fun locator() = GreeterLocator()
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/greeter.provider/build.gradle.kts
@@ -1,0 +1,24 @@
+import org.javamodularity.moduleplugin.extensions.JavadocModuleOptions
+
+dependencies {
+    implementation(project(":greeter.api"))
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
+    implementation("com.google.code.findbugs:jsr305:3.0.2")
+    implementation("javax.annotation:jsr250-api:1.0")
+
+    testImplementation("org.hamcrest:hamcrest:2.1+")
+}
+
+patchModules.config = listOf(
+        "java.annotation=jsr305-3.0.2.jar"
+)
+
+modularity {
+    patchModule("java.annotation", "jsr250-api-1.0.jar")
+}
+
+tasks.javadoc {
+    extensions.configure<JavadocModuleOptions> {
+        addModules = listOf("java.sql")
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider/src/main/java/module-info.java
+++ b/test-project-kotlin-pre-1-7/greeter.provider/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+import examples.greeter.api.Greeter;
+
+module greeter.provider {
+    requires greeter.api;
+    requires kotlin.stdlib;
+    provides Greeter with examples.greeter.Friendly;
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider/src/main/kotlin/examples/greeter/Friendly.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider/src/main/kotlin/examples/greeter/Friendly.kt
@@ -1,0 +1,12 @@
+package examples.greeter
+
+import examples.greeter.api.Greeter
+import java.io.*
+
+class Friendly: Greeter {
+    override fun hello(): String {
+        val stream = javaClass.getResourceAsStream("/greeting.txt")
+        val reader = BufferedReader(InputStreamReader(stream, "utf-8"))
+        return reader.readLine()
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider/src/main/resources/greeting.txt
+++ b/test-project-kotlin-pre-1-7/greeter.provider/src/main/resources/greeting.txt
@@ -1,0 +1,1 @@
+welcome

--- a/test-project-kotlin-pre-1-7/greeter.provider/src/test/kotlin/examples/greeter/FriendlyTest.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider/src/test/kotlin/examples/greeter/FriendlyTest.kt
@@ -1,0 +1,12 @@
+package examples.greeter
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class FriendlyTest {
+    @Test
+    fun testGreeting() {
+        val greeting = Friendly().hello()
+        assertTrue(greeting.contains("welcome"))
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider/src/test/kotlin/examples/greeter/ScriptingTest.kt
+++ b/test-project-kotlin-pre-1-7/greeter.provider/src/test/kotlin/examples/greeter/ScriptingTest.kt
@@ -1,0 +1,14 @@
+package examples.greeter
+
+import javax.script.*
+import org.junit.jupiter.api.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+
+class ScriptingTest {
+    @Test
+    fun testScripting() {
+        val manager = ScriptEngineManager()
+        assertThat(manager.getEngineFactories(), not(nullValue()))
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.provider/src/test/kotlin/module-info.test
+++ b/test-project-kotlin-pre-1-7/greeter.provider/src/test/kotlin/module-info.test
@@ -1,0 +1,7 @@
+// make module visible
+--add-modules
+  java.scripting,org.hamcrest
+
+// "requires java.scripting"
+--add-reads
+  greeter.provider=java.scripting,org.hamcrest

--- a/test-project-kotlin-pre-1-7/greeter.runner/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/greeter.runner/build.gradle.kts
@@ -1,0 +1,36 @@
+import org.javamodularity.moduleplugin.extensions.RunModuleOptions
+
+plugins {
+    application
+}
+
+//region https://docs.gradle.org/current/userguide/kotlin_dsl.html#using_kotlin_delegated_properties
+val moduleName: String by project
+val run by tasks.existing(JavaExec::class) // https://youtrack.jetbrains.com/issue/KT-28013
+//endregion
+
+dependencies {
+    implementation(project(":greeter.api"))
+    runtimeOnly(project(":greeter.provider"))
+}
+
+application {
+    mainClass.set("examples.RunnerKt")
+    mainModule.set(moduleName)
+    applicationDefaultJvmArgs = listOf("-Dgreeter.sender=gradle-modules-plugin")
+}
+
+modularity {
+    patchModule("java.annotation", "jsr305-3.0.2.jar")
+}
+patchModules.config = listOf(
+    "java.annotation=jsr250-api-1.0.jar"
+)
+
+(run) {
+    extensions.configure<RunModuleOptions> {
+        addModules = listOf("java.sql")
+    }
+
+    jvmArgs = listOf("-Dgreeter.sender=gradle-modules-plugin")
+}

--- a/test-project-kotlin-pre-1-7/greeter.runner/src/main/java/module-info.java
+++ b/test-project-kotlin-pre-1-7/greeter.runner/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+import examples.greeter.api.Greeter;
+
+module greeter.runner {
+    requires greeter.api;
+    requires kotlin.stdlib;
+    uses Greeter;
+}

--- a/test-project-kotlin-pre-1-7/greeter.runner/src/main/kotlin/examples/Runner.kt
+++ b/test-project-kotlin-pre-1-7/greeter.runner/src/main/kotlin/examples/Runner.kt
@@ -1,0 +1,21 @@
+package examples
+
+import examples.greeter.api.Greeter
+
+import java.util.ServiceLoader
+
+fun main(args: Array<String>) {
+    println("args: " + java.util.Arrays.asList(*args))
+    println("greeter.sender: " + System.getProperty("greeter.sender"))
+    val greeter = ServiceLoader.load(Greeter::class.java)
+            .findFirst()
+            .orElseThrow{RuntimeException("No Greeter found!")}
+    println(greeter.hello())
+
+    val resource = object: Any() {}.javaClass.getResourceAsStream("/resourcetest.txt")
+    if(resource == null) {
+        throw RuntimeException("Couldn't load resource")
+    }
+    ModuleLayer.boot().modules().map(Module::getName)
+            .find{it == "java.sql"} ?: throw RuntimeException("Expected module java.sql not found")
+}

--- a/test-project-kotlin-pre-1-7/greeter.startscripts/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/greeter.startscripts/build.gradle.kts
@@ -1,0 +1,48 @@
+import org.javamodularity.moduleplugin.tasks.ModularCreateStartScripts
+import org.javamodularity.moduleplugin.tasks.ModularJavaExec
+
+plugins {
+    application
+}
+
+//region https://docs.gradle.org/current/userguide/kotlin_dsl.html#using_kotlin_delegated_properties
+val moduleName: String by project
+val installDist by tasks
+//endregion
+
+dependencies {
+    implementation(project(":greeter.api"))
+    runtimeOnly(project(":greeter.provider"))
+}
+
+modularity {
+    patchModule("java.annotation", "jsr250-api-1.0.jar")
+    patchModule("java.annotation", "jsr305-3.0.2.jar")
+}
+
+application {
+    mainClass.set("startscripts.MainDemoKt")
+    mainModule.set(moduleName)
+    applicationName = "demo"
+    applicationDefaultJvmArgs = listOf("-Xmx128m")
+}
+
+File("${project.projectDir}/src/main/kotlin/startscripts")
+        .listFiles({ _, name -> Regex("Demo.*\\.kt") matches name })
+        .forEach { file ->
+            val demoClassName = file.name.removeSuffix(".kt")
+
+            val runDemo = tasks.create<ModularJavaExec>("run$demoClassName") {
+                group = "Demo"
+                description = "Run the $demoClassName program"
+                main = "$moduleName/startscripts.${demoClassName}Kt"
+                jvmArgs = listOf("-Xmx128m")
+            }
+
+            val createScripts = tasks.create<ModularCreateStartScripts>("createStartScripts$demoClassName") {
+                runTask = runDemo
+                applicationName = demoClassName.decapitalize()
+            }
+
+            installDist.finalizedBy(createScripts)
+        }

--- a/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/java/module-info.java
+++ b/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+import examples.greeter.api.Greeter;
+
+module greeter.startscripts {
+    requires greeter.api;
+    requires kotlin.stdlib;
+
+    uses Greeter;
+}

--- a/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/Demo1.kt
+++ b/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/Demo1.kt
@@ -1,0 +1,5 @@
+package startscripts
+
+fun main(args: Array<String>) {
+    DemoHelper.greet("Demo1", args)
+}

--- a/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/Demo2.kt
+++ b/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/Demo2.kt
@@ -1,0 +1,5 @@
+package startscripts
+
+fun main(args: Array<String>) {
+    DemoHelper.greet("Demo2", args)
+}

--- a/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/DemoHelper.kt
+++ b/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/DemoHelper.kt
@@ -1,0 +1,16 @@
+package startscripts
+
+import examples.greeter.api.Greeter
+import java.util.ServiceLoader
+
+object DemoHelper {
+    fun greet(appName: String, args: Array<String>) {
+        val greeter = ServiceLoader.load(Greeter::class.java)
+                .findFirst()
+                .orElseThrow{RuntimeException("No Greeter found!")}
+        val addition = System.getProperty("greeting.addition", "").let {
+            if(it.isBlank()) "" else " $it"
+        }
+        println("$appName: ${greeter.hello()}$addition" + args.joinToString(" and ", ", ", "!"))
+    }
+}

--- a/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/MainDemo.kt
+++ b/test-project-kotlin-pre-1-7/greeter.startscripts/src/main/kotlin/startscripts/MainDemo.kt
@@ -1,0 +1,5 @@
+package startscripts
+
+fun main(args: Array<String>) {
+    DemoHelper.greet("MainDemo", args)
+}

--- a/test-project-kotlin-pre-1-7/local_maven_settings.gradle
+++ b/test-project-kotlin-pre-1-7/local_maven_settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroup 'org.javamodularity.moduleplugin' // by 'publishToMavenLocal' task
+            }
+        }
+        mavenCentral {
+            content {
+                includeGroup 'com.github.javaparser'
+            }
+        }
+    }
+}
+
+apply from: 'settings.gradle'

--- a/test-project-kotlin-pre-1-7/settings.gradle
+++ b/test-project-kotlin-pre-1-7/settings.gradle
@@ -1,0 +1,16 @@
+import org.gradle.util.GradleVersion
+
+rootProject.name = 'test-project-kotlin-pre-1-7'
+
+include 'greeter.api'
+
+include 'greeter.provider'
+include 'greeter.provider.test'
+
+if(GradleVersion.current().compareTo(GradleVersion.version("5.6")) >= 0) {
+    include 'greeter.provider.testfixture'
+}
+
+include 'greeter.runner'
+include 'greeter.javaexec'
+include 'greeter.startscripts'

--- a/test-project-kotlin-pre-1-7/smoke_test_settings.gradle
+++ b/test-project-kotlin-pre-1-7/smoke_test_settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal().with {
+            content {
+                excludeGroup 'org.javamodularity.moduleplugin' // added to the classpath by the smoke test
+            }
+        }
+    }
+}
+
+apply from: 'settings.gradle'

--- a/test-project-kotlin/greeter.provider/src/main/java/module-info.java
+++ b/test-project-kotlin/greeter.provider/src/main/java/module-info.java
@@ -3,5 +3,6 @@ import examples.greeter.api.Greeter;
 module greeter.provider {
     requires greeter.api;
     requires kotlin.stdlib;
+    requires java.annotation;
     provides Greeter with examples.greeter.Friendly;
 }

--- a/test-project-kotlin/greeter.provider/src/main/kotlin/examples/greeter/Friendly.kt
+++ b/test-project-kotlin/greeter.provider/src/main/kotlin/examples/greeter/Friendly.kt
@@ -2,7 +2,9 @@ package examples.greeter
 
 import examples.greeter.api.Greeter
 import java.io.*
+import javax.annotation.concurrent.Immutable;
 
+@Immutable
 class Friendly: Greeter {
     override fun hello(): String {
         val stream = javaClass.getResourceAsStream("/greeting.txt")


### PR DESCRIPTION
fixes: https://github.com/java9-modularity/gradle-modules-plugin/issues/212

The gradle plugin for Kotlin 1.7 included breaking changes, including making `KotlinCompile` no longer derive from `AbstractCompile`, breaking this plugin. (See https://kotlinlang.org/docs/whatsnew17.html#changes-in-compile-tasks).

The fix is to factor out the information required from compile tasks into a `CompileTaskWrapper` interface and provide different impls for tasks derived from `AbstractCompile` vs those that are not (like `KotlinCompile`). The latter uses reflection to access the needed methods. (I've gone with reflection as it means we don't need to bring in Kotlin plugin dependencies).

