### PR TITLE
Avoid reference to deprecated property. (#221)

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesHelper.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesHelper.java
@@ -12,6 +12,7 @@ import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.jvm.tasks.Jar;
+import org.gradle.util.GradleVersion;
 import org.javamodularity.moduleplugin.JavaProjectHelper;
 import org.javamodularity.moduleplugin.extensions.CompileModuleOptions;
 import org.javamodularity.moduleplugin.internal.StreamHelper;
@@ -128,6 +129,11 @@ public class MergeClassesHelper {
 
         @Override
         public File getDestinationDir() {
+            if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {
+                // AbstractCompile#getDestinationDirectory() is supported from Gradle 6.1
+                // https://docs.gradle.org/6.1/javadoc/org/gradle/api/tasks/compile/AbstractCompile.html#getDestinationDirectory--
+                return task.getDestinationDirectory().get().getAsFile();
+            }
             return task.getDestinationDir();
         }
 


### PR DESCRIPTION
This addresses Issue #221 with the same check to guard access to the deprecated property as found at https://github.com/java9-modularity/gradle-modules-plugin/blob/cc1f0fdc1e6aadfb1054ae2373fd10b1d5da2b6b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileModuleInfoTask.java#L104