### PR TITLE
Fix for java9-modularity#224

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/ModularJavaExec.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/ModularJavaExec.java
@@ -5,6 +5,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskAction;
@@ -63,6 +64,7 @@ public class ModularJavaExec extends JavaExec {
         super.setJvmArgs(arguments);
     }
 
+    @Input
     @Override
     public String getMain() {
         if(GradleVersion.current().compareTo(GradleVersion.version("6.4")) >= 0) {


### PR DESCRIPTION
Seems to fix the issue, Gradle >= 8 stopped complaining and all unit tests passed.