### PR TITLE
Patch-in generated resources during testing

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/TestTask.java
@@ -115,7 +115,12 @@ public class TestTask extends AbstractModulePluginTask {
                 .map(File::toPath)
                 .filter(Files::isDirectory);
 
-        return Stream.concat(classesFileStream, resourceFileStream);
+        Stream<Path> additionalResourceFileStream = sourceSets.stream()
+                .flatMap(sourceSet -> sourceSet.getOutput().getDirs().getFiles().stream())
+                .map(File::toPath)
+                .filter(Files::isDirectory);
+
+        return Stream.concat(Stream.concat(classesFileStream, resourceFileStream), additionalResourceFileStream);
     }
 
     private TaskOption buildAddReadsOption(TestEngine testEngine) {

--- a/test-project-kotlin/greeter.provider.test/build.gradle.kts
+++ b/test-project-kotlin/greeter.provider.test/build.gradle.kts
@@ -11,3 +11,27 @@ modularity {
 val compileTestJava: JavaCompile by tasks.named("compileTestJava")
 val moduleOptions: org.javamodularity.moduleplugin.extensions.ModuleOptions by compileTestJava.extensions
 moduleOptions.addModules = listOf("jdk.unsupported")
+
+val generatedResourcesDir = "generated/resources/test";
+
+sourceSets {
+    test {
+        // Add additional output directory for generated resources.
+        // See org.gradle.api.tasks.SourceSetOutput for more info.
+        output.dir(layout.buildDirectory.dir(generatedResourcesDir))
+    }
+}
+
+val generateResources = tasks.register("generateResources") {
+    doLast {
+        val outputFile = layout.buildDirectory.file("$generatedResourcesDir/generated-resource.txt")
+        outputFile.get().asFile.parentFile.mkdirs()
+        outputFile.get().asFile.writeText("some content")
+
+        println("Resource file generated at: ${outputFile.get().asFile.absolutePath}")
+    }
+}
+
+tasks.test {
+    dependsOn(generateResources)
+}

--- a/test-project-kotlin/greeter.provider.test/src/test/kotlin/tests/GreeterTest.kt
+++ b/test-project-kotlin/greeter.provider.test/src/test/kotlin/tests/GreeterTest.kt
@@ -10,4 +10,12 @@ class GreeterTest {
         val greeter = GreeterLocator().findGreeter()
         assertFalse(greeter.hello().isBlank())
     }
+
+    @Test
+    fun testGeneratedResource() {
+        val resource = object: Any() {}.javaClass.getResourceAsStream("/generated-resource.txt")
+        if (resource == null) {
+            throw RuntimeException("Couldn't load generated resource")
+        }
+    }
 }


### PR DESCRIPTION
fixes: https://github.com/java9-modularity/gradle-modules-plugin/issues/227

Enhance `TestTask` to patch-in additional resource directories containing generated resources, as added via `org.gradle.api.tasks.SourceSetOutput.dir()` methods, so that all resources are accessible when running unit tests.