### PR TITLE
Bump com.gradle.plugin-publish to 1.2.1 AND com.github.johnrengelman.shadow to 7.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'eclipse'
     id 'java-gradle-plugin'
     id 'maven-publish' // used for publishing to local maven repository
-    id 'com.gradle.plugin-publish' version '0.12.0'
-    id 'com.github.johnrengelman.shadow' version '5.0.0'
+    id 'com.gradle.plugin-publish' version '1.2.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'com.github.ben-manes.versions' version '0.51.0'
 }
 
@@ -44,7 +44,7 @@ dependencies {
 
 shadowJar {
     configurations = [project.configurations.plugin]
-    classifier = null
+    archiveClassifier = null
     dependencies {
         include(dependency('com.github.javaparser:javaparser-symbol-solver-core'))
         include(dependency('com.github.javaparser:javaparser-symbol-solver-logic'))


### PR DESCRIPTION
Updates to the latest `com.gradle.plugin-publish` plugin, which required updating `com.github.johnrengelman.shadow` from `5.0.0` to `7.1.2`.

It's not possible to update to a later version of `com.github.johnrengelman.shadow` as v8+ requires Gradle 8+, which would mean dropping support for earlier versions of Gradle.  One for another day.

Replaces https://github.com/java9-modularity/gradle-modules-plugin/pull/237