### PR TITLE
Fix compatibility issue with Gradle 7.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,23 @@ Compatability
 
 The plugin is compatible with the following Gradle versions:
 
-| Gradle version | Min plugin version                                                                     | Max plugin version |
-|----------------|----------------------------------------------------------------------------------------|--------------------|
-| 5.* -> 7.5.+   | 1.+                                                                                    |                    |
-| 7.6+           | See [issue #258](https://github.com/java9-modularity/gradle-modules-plugin/issues/258) |                    |
+| Gradle version | Min plugin version                                                                     |
+|----------------|----------------------------------------------------------------------------------------|
+| 5.* -> 7.5.+   | 1.+                                                                                    |
+| 7.6+           | 1.8.14                                                                                 |
+| 8.+            | See [issue #260](https://github.com/java9-modularity/gradle-modules-plugin/issues/260) |
 
 The plugin is compatible with the following Java versions:
 
 | Java version | Min plugin version |
 |--------------|--------------------|
-| 11+          | 1.0.0              |
+| 11+          | 1.+                |
 
 The plugin is compatible with the following Kotlin versions:
 
 | Kotlin version | Min plugin version |
 |----------------|--------------------|
-| 1.0.* -> 1.6.* | 1.0.0              |
+| 1.0.* -> 1.6.* | 1.+                |
 | 1.7+           | 1.8.12             |
 
 Setup

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/MergeClassesTask.java
@@ -38,7 +38,10 @@ public class MergeClassesTask extends AbstractModulePluginTask {
         mergeClasses.into(helper().getMergedDir());
         mergeClasses.onlyIf(task -> mergeClassesHelper().isMergeRequired());
 
-        Stream.of(ApplicationPlugin.TASK_RUN_NAME, JavaPlugin.TEST_TASK_NAME, JavaProjectHelper.COMPILE_TEST_FIXTURES_JAVA_TASK_NAME)
+        Stream.of(ApplicationPlugin.TASK_RUN_NAME,
+                        JavaPlugin.TEST_TASK_NAME,
+                        JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME,
+                        JavaProjectHelper.COMPILE_TEST_FIXTURES_JAVA_TASK_NAME)
                 .map(helper()::findTask)
                 .flatMap(Optional::stream)
                 .forEach(task -> task.dependsOn(mergeClasses));

--- a/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
+++ b/src/test/java/org/javamodularity/moduleplugin/ModulePluginSmokeTest.java
@@ -32,7 +32,7 @@ class ModulePluginSmokeTest {
     private enum GradleVersion {
         v5_1, v5_6,
         v6_3, v6_4_1, v6_5_1, v6_8_3,
-        v7_0, v7_5_1
+        v7_0, v7_6_4
         ;
 
         @Override


### PR DESCRIPTION
fixes: https://github.com/java9-modularity/gradle-modules-plugin/issues/258

Gradle 7.6 is executing tasks in a different order, with `mergeClasses` being run _after_ `compileTestJava`.   This results in `compileTestJava` failing as it can't find the `module-info.class` which is generated by `mergeClasses`.

Fix looks to be to have the `compileTestJava` task, i.e. `JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME`, depend on the `mergeClasses` task. Thereby ensuring `mergeClasses` runs first and the `module-info.class` is available to `compileTestJava`.

It is possible/likely that the `JavaPlugin.TEST_TASK_NAME` task, i.e. `test` task, no longer needs to depend on `mergeClasses`.  However, removing it may cause problems if there are other tasks run by `test` that require the output of `mergeClasses`.  Of course, those tasks may also run foul of the re-ordering happening with Gradle 7.6.


