### PR TITLE
Update tests to cover Gradle 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,12 @@ An example application using this plugin is available [here](https://github.com/
 Compatability
 ===
 
-The plugin is compatible with the following Gradle versions:
-
-| Gradle version | Min plugin version                                                                     |
-|----------------|----------------------------------------------------------------------------------------|
-| 5.* -> 7.5.+   | 1.+                                                                                    |
-| 7.6+           | 1.8.14                                                                                 |
-| 8.+            | See [issue #260](https://github.com/java9-modularity/gradle-modules-plugin/issues/260) |
-
-The plugin is compatible with the following Java versions:
-
-| Java version | Min plugin version |
-|--------------|--------------------|
-| 11+          | 1.+                |
-
-The plugin is compatible with the following Kotlin versions:
-
-| Kotlin version | Min plugin version |
-|----------------|--------------------|
-| 1.0.* -> 1.6.* | 1.+                |
-| 1.7+           | 1.8.12             |
+| Plugin Version     | Gradle Versions | Java Version | Kotlin Version | Notes                                                                                      |
+|--------------------|-----------------|--------------|----------------|--------------------------------------------------------------------------------------------|
+| - -> 1.18.12       | 5.+ -> 7.5.+    | 11+          | 1.0.+ -> 1.6.+ |                                                                                            |
+| 1.18.12 -> 1.18.13 | 5.+ -> 7.5.+    | 11+          | 1.0.+ -> 1.9.+ | Adds support for Kotlin 1.7 and above.                                                     |
+| 1.18.14            | 5.+ -> 7.6.+    | 11+          | 1.0.+ -> 1.9.+ | Fixes compatibility issue with Gradle 7.6                                                  |
+| 1.18.15 -> +       | 5.+ -> 8.6.+    | 11+          | 1.6.+ -> 1.9.+ | Fixes compatibility issues with Gradle 8.0.<br>Use JUnit v5.8.0 or above if using Gradle 8 |
 
 Setup
 ===

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ configurations {
     compile.extendsFrom plugin
 }
 
+def jUnitVersion = '5.10.2'
+
 dependencies {
     implementation gradleApi()
     implementation 'org.jooq:joor:0.9.15'
@@ -35,11 +37,11 @@ dependencies {
     testImplementation gradleTestKit()
     testImplementation 'com.google.guava:guava-base:r03'
     testImplementation 'com.google.guava:guava-io:r03'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$jUnitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$jUnitVersion"
     testImplementation 'org.junit-pioneer:junit-pioneer:2.2.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2' // required when testing in Eclipse
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$jUnitVersion"
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher' // required when testing in Eclipse
 }
 
 shadowJar {
@@ -57,7 +59,7 @@ shadowJar {
 jar.enabled = false
 jar.dependsOn shadowJar
 
-processResources.duplicatesStrategy = 'exclude'
+processResources.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
 configurations {
     [apiElements, runtimeElements].each {

--- a/test-project-groovy/gradle.properties
+++ b/test-project-groovy/gradle.properties
@@ -1,2 +1,2 @@
-jUnitVersion = 5.6.2
-jUnitPlatformVersion = 1.6.2
+jUnitVersion = 5.10.2
+jUnitPlatformVersion = 1.10.2

--- a/test-project-kotlin-pre-1-7/build.gradle.kts
+++ b/test-project-kotlin-pre-1-7/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
     id("org.javamodularity.moduleplugin") version "1.8.14" apply false
 }
 
+if (gradle.gradleVersion >= "8.0") {
+    throw GradleException("The Kotlin version used in this build isn't compatible with Gradle 8. " +
+            "This project should be excluded when testing with Gradle version 8 and above.")
+}
+
 subprojects {
     apply(plugin = "kotlin")
     apply(plugin = "org.javamodularity.moduleplugin")

--- a/test-project-kotlin-pre-1-7/gradle.properties
+++ b/test-project-kotlin-pre-1-7/gradle.properties
@@ -1,2 +1,2 @@
-jUnitVersion = 5.6.2
-jUnitPlatformVersion = 1.6.2
+jUnitVersion = 5.10.2
+jUnitPlatformVersion = 1.10.2

--- a/test-project-kotlin/build.gradle.kts
+++ b/test-project-kotlin/build.gradle.kts
@@ -11,8 +11,6 @@ subprojects {
 
     //region https://docs.gradle.org/current/userguide/kotlin_dsl.html#using_kotlin_delegated_properties
     val test by tasks.existing(Test::class)
-    val build by tasks
-    val javadoc by tasks
 
     val implementation by configurations
     val testImplementation by configurations
@@ -23,9 +21,18 @@ subprojects {
     //endregion
 
     //region KOTLIN
-    tasks.withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "1.8"
+    if (gradle.gradleVersion >= "8.0") {
+        configure<JavaPluginExtension> {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(11))
+            }
+        }
+    } else {
+        tasks.withType<KotlinCompile> {
+            kotlinOptions.jvmTarget = "1.8"
+        }
     }
+
     dependencies {
         implementation(kotlin("stdlib-jdk8"))
     }
@@ -54,6 +61,4 @@ subprojects {
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jUnitVersion")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher:$jUnitPlatformVersion")
     }
-
-//    build.dependsOn(javadoc) // TODO: No public or protected classes found to document
 }

--- a/test-project-kotlin/gradle.properties
+++ b/test-project-kotlin/gradle.properties
@@ -1,2 +1,2 @@
-jUnitVersion = 5.6.2
-jUnitPlatformVersion = 1.6.2
+jUnitVersion = 5.10.2
+jUnitPlatformVersion = 1.10.2

--- a/test-project-kotlin/greeter.startscripts/build.gradle.kts
+++ b/test-project-kotlin/greeter.startscripts/build.gradle.kts
@@ -35,7 +35,12 @@ File("${project.projectDir}/src/main/kotlin/startscripts")
             val runDemo = tasks.create<ModularJavaExec>("run$demoClassName") {
                 group = "Demo"
                 description = "Run the $demoClassName program"
-                main = "$moduleName/startscripts.${demoClassName}Kt"
+                if (gradle.gradleVersion >= "8.0") {
+                    mainClass.set("startscripts.${demoClassName}Kt")
+                    mainModule.set(moduleName)
+                } else {
+                    main = "$moduleName/startscripts.${demoClassName}Kt"
+                }
                 jvmArgs = listOf("-Xmx128m")
             }
 

--- a/test-project-mixed/gradle.properties
+++ b/test-project-mixed/gradle.properties
@@ -1,2 +1,2 @@
-jUnitVersion = 5.6.2
-jUnitPlatformVersion = 1.6.2
+jUnitVersion = 5.10.2
+jUnitPlatformVersion = 1.10.2

--- a/test-project/gradle.properties
+++ b/test-project/gradle.properties
@@ -1,2 +1,2 @@
-jUnitVersion = 5.6.2
-jUnitPlatformVersion = 1.6.2
+jUnitVersion = 5.10.2
+jUnitPlatformVersion = 1.10.2


### PR DESCRIPTION
fixes: https://github.com/java9-modularity/gradle-modules-plugin/issues/260

Aside from the incompatibility between Gradle 8 and versions of JUnit prior to 5.8.0, no other issues were found.