### PR TITLE
Make CompileTestModuleOptions consistent with documentation

### DIFF
--- a/src/main/java/org/javamodularity/moduleplugin/extensions/CompileTestModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/CompileTestModuleOptions.java
@@ -3,13 +3,19 @@ package org.javamodularity.moduleplugin.extensions;
 import org.gradle.api.Project;
 
 public class CompileTestModuleOptions extends ModuleOptions {
+
     private boolean compileOnClasspath;
 
     public CompileTestModuleOptions(Project project) {
         super(project);
     }
 
+    @Deprecated(since = "1.8.16", forRemoval = true)
     public boolean isCompileOnClasspath() {
+        return compileOnClasspath;
+    }
+
+    public boolean getCompileOnClasspath() {
         return compileOnClasspath;
     }
 

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/CompileTestTask.java
@@ -42,8 +42,8 @@ public class CompileTestTask extends AbstractModulePluginTask {
         var moduleOptions = compileTestJava.getExtensions()
                 .create("moduleOptions", CompileTestModuleOptions.class, project);
         project.afterEvaluate(p -> {
-            LOGGER.info(compileTestJava.getName() +  ".compileOnClasspath: {}", moduleOptions.isCompileOnClasspath());
-            if(!moduleOptions.isCompileOnClasspath()) {
+            LOGGER.info(compileTestJava.getName() +  ".compileOnClasspath: {}", moduleOptions.getCompileOnClasspath());
+            if(!moduleOptions.getCompileOnClasspath()) {
                 // don't convert to lambda: https://github.com/java9-modularity/gradle-modules-plugin/issues/54
                 compileTestJava.doFirst(new Action<>() {
                     @Override

--- a/test-project-groovy/build.gradle
+++ b/test-project-groovy/build.gradle
@@ -36,4 +36,17 @@ subprojects {
             exclude module: 'groovy-xml'
         }
     }
+
+    test {
+        moduleOptions {
+            runOnClasspath = false
+        }
+    }
+
+    compileTestJava {
+        moduleOptions {
+            compileOnClasspath = false
+        }
+    }
+
 }

--- a/test-project-kotlin/build.gradle.kts
+++ b/test-project-kotlin/build.gradle.kts
@@ -11,6 +11,7 @@ subprojects {
 
     //region https://docs.gradle.org/current/userguide/kotlin_dsl.html#using_kotlin_delegated_properties
     val test by tasks.existing(Test::class)
+    val compileTestJava by tasks.existing(JavaCompile::class)
 
     val implementation by configurations
     val testImplementation by configurations
@@ -52,6 +53,16 @@ subprojects {
 
         testLogging {
             events("PASSED", "FAILED", "SKIPPED", "STANDARD_OUT")
+        }
+
+        extensions.configure(org.javamodularity.moduleplugin.extensions.TestModuleOptions::class) {
+            runOnClasspath = false
+        }
+    }
+
+    compileTestJava {
+        extensions.configure(org.javamodularity.moduleplugin.extensions.CompileTestModuleOptions::class) {
+            compileOnClasspath = false
         }
     }
 


### PR DESCRIPTION
The README section for [Fall-back to classpath mode](https://github.com/java9-modularity/gradle-modules-plugin?tab=readme-ov-file#fall-back-to-classpath-mode) states that using the Kotlin DSL, you can enable classpath mode while running tests with:

```kts
tasks {
  compileTestJava {
        extensions.configure(CompileTestModuleOptions::class) {
            compileOnClasspath = true
        }
    }
}
```

In fact, in version 1.8.15 of the plugin, you have to write `isCompileOnClasspath = true`.  The reason for this is that the accessor needs to be called `getCompileOnClasspath()` for it to be treated as a property in Kotlin.

Note that this doesn't affect the Groovy DSL, and that `TestModuleOptions` works as documented for both Kotlin and Groovy.

I've adjusted the tests to demonstrate the problem, implemented a fix, and deprecated the old method.

Let me know if you want to take a different approach, or you'd like anything adjusting.