### PR TITLE
Add usage of java Command-Line Argument File on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,6 +943,24 @@ Examples on how and where Gradle's eclipse-plugin could (and should) be improved
 `.classpath`-file is affected if the feature is enabled are available on
 [GitHub](https://github.com/Alfred-65/gradle-modules-plugin.investigation).
 
+Preventing "command line too long" errors
+===
+When using many modules, the command line for `--module-path` can become too long.
+A workaround is to use Java's [Command-Line Argument Files](https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-4856361B-8BFD-4964-AE84-121F5F6CF111).
+The workaround can be enabled by setting `createCommandLineArgumentFile` to `true` in the `moduleOptions` part in the `run` configuration.
+
+<details open>
+<summary>Groovy DSL</summary>
+
+```groovy
+run {
+    moduleOptions {
+        createCommandLineArgumentFile = true
+    }
+}
+```
+</details>
+
 
 Limitations
 ===

--- a/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
+++ b/src/main/java/org/javamodularity/moduleplugin/ModuleSystemPlugin.java
@@ -19,9 +19,9 @@ public class ModuleSystemPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         if(GradleVersion.current().compareTo(GradleVersion.version("5.1")) < 0) {
-            LOGGER.warn("WARNING: You use " + GradleVersion.current() +
-                    ". The minimum version supported (with some limitations) by this plugin is 5.1." +
-                    "  It is strongly recommended to use at least Gradle 5.6.");
+            LOGGER.warn("WARNING: You use {}." +
+                    " The minimum version supported (with some limitations) by this plugin is 5.1." +
+                    " It is strongly recommended to use at least Gradle 5.6.", GradleVersion.current());
         }
         project.getPlugins().apply(JavaPlugin.class);
         new ModuleName().findModuleName(project).ifPresent(moduleName -> configureModularity(project, moduleName));

--- a/src/main/java/org/javamodularity/moduleplugin/extensions/RunModuleOptions.java
+++ b/src/main/java/org/javamodularity/moduleplugin/extensions/RunModuleOptions.java
@@ -4,6 +4,16 @@ import org.gradle.api.Project;
 
 public class RunModuleOptions extends RuntimeModuleOptions {
 
+    private Boolean createCommandLineArgumentFile = false;
+
+    public Boolean getCreateCommandLineArgumentFile() {
+        return createCommandLineArgumentFile;
+    }
+
+    public void setCreateCommandLineArgumentFile(Boolean createCommandLineArgumentFile) {
+        this.createCommandLineArgumentFile = createCommandLineArgumentFile;
+    }
+
     public RunModuleOptions(Project project) {
         super(project);
     }

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
@@ -64,6 +64,7 @@ public class RunTaskMutator extends AbstractExecutionMutator {
                     execTask.setJvmArgs(newJvmArgs);
                     LOGGER.info("Patched jvmArgs for task {}: {}", execTask.getName(), newJvmArgs);
                 } catch (IOException e) {
+                    LOGGER.warn("Could not create temporary file for jvmArgs. Falling back to default behavior.", e);
                     execTask.setJvmArgs(jvmArgs);
                 }
                 execTask.setClasspath(project.files());

--- a/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
+++ b/src/main/java/org/javamodularity/moduleplugin/tasks/RunTaskMutator.java
@@ -63,6 +63,7 @@ public class RunTaskMutator extends AbstractExecutionMutator {
                     newJvmArgs.add("@" + parameterFile.toAbsolutePath());
                     execTask.setJvmArgs(newJvmArgs);
                     LOGGER.info("Patched jvmArgs for task {}: {}", execTask.getName(), newJvmArgs);
+                    parameterFile.toFile().deleteOnExit();
                 } catch (IOException e) {
                     LOGGER.warn("Could not create temporary file for jvmArgs. Falling back to default behavior.", e);
                     execTask.setJvmArgs(jvmArgs);


### PR DESCRIPTION
Fixes https://github.com/java9-modularity/gradle-modules-plugin/issues/281

Tested locally. Works. ("Internal" issue https://github.com/InAnYan/jabref/issues/5).

~~One could add an additional configuration setting to enable/disable the feature to prevent temporary files to be created.~~

I added the option `createCommandLineArgumentFile` to enable the functionality explicitly (disabled as default).



